### PR TITLE
chore: add codecov coverage workflow and readme badge

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,49 @@
+name: Coverage
+on:
+  push: { branches: [main] }
+  pull_request:
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Codecov OIDC upload (unavailable on fork PRs; see use_oidc below)
+    steps:
+      - uses: actions/checkout@v4
+        with: { persist-credentials: false }
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.5"
+        env:
+          phpts: ts # thread-safe (ZTS)
+
+      - name: Build deps for bindgen/cc
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends build-essential pkg-config libclang-dev
+
+      - name: Expose the ZTS embed lib
+        run: |
+          LIBPHP=$(find "$(php-config --prefix)" /usr/lib -name 'libphp*.so' 2>/dev/null | head -1)
+          test -n "$LIBPHP" || { echo "no ZTS libphp.so from setup-php"; exit 1; }
+          echo "LD_LIBRARY_PATH=$(dirname "$LIBPHP")" >> "$GITHUB_ENV"
+          echo "RUSTFLAGS=-L native=$(dirname "$LIBPHP")" >> "$GITHUB_ENV"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with: { components: llvm-tools-preview }
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Generate coverage (lcov)
+        run: >-
+          cargo llvm-cov --workspace --lcov --output-path lcov.info
+          --ignore-filename-regex '(crates/integration_tests/|bindings\.rs$|/src/main\.rs$)'
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          use_oidc: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ target
 
 /target
 .envrc
+
+# Coverage artifacts (cargo-llvm-cov)
+lcov.info
+codecov.json
+*.profraw
+*.profdata

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,5 @@ target
 
 # Coverage artifacts (cargo-llvm-cov)
 lcov.info
-codecov.json
 *.profraw
 *.profdata

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ZTS_LIB        := $(HOME)/.local/php-zts/lib
 NTS_PHP_CONFIG := /usr/bin/php-config
 NTS_LIB        := /usr/lib64
 
-.PHONY: test test_zts test_nts
+.PHONY: test test_zts test_nts coverage
 
 test: test_zts test_nts
 
@@ -20,3 +20,11 @@ test_nts:
 	LD_LIBRARY_PATH=$(NTS_LIB) \
 	RUSTFLAGS="-L native=$(NTS_LIB)" \
 	cargo test --workspace
+
+# Requires: cargo install cargo-llvm-cov && rustup component add llvm-tools-preview
+coverage:
+	CARGO_TARGET_DIR=target/coverage \
+	PHP_CONFIG=$(ZTS_PHP_CONFIG) \
+	LD_LIBRARY_PATH=$(ZTS_LIB) \
+	cargo llvm-cov --workspace --lcov --output-path lcov.info \
+		--ignore-filename-regex '(crates/integration_tests/|bindings\.rs$$|/src/main\.rs$$)'

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # core
+[![codecov](https://codecov.io/gh/rapira-rs/core/branch/main/graph/badge.svg)](https://app.codecov.io/gh/rapira-rs/core)
+
 SAPI core API used to integrate with PHP SAPI and provide API for plugins

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # core
-[![codecov](https://codecov.io/gh/rapira-rs/core/branch/main/graph/badge.svg)](https://app.codecov.io/gh/rapira-rs/core)
+[![codecov](https://codecov.io/gh/rapira-rs/core/graph/badge.svg)](https://app.codecov.io/gh/rapira-rs/core)
 
 SAPI core API used to integrate with PHP SAPI and provide API for plugins

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,3 @@ coverage:
 comment:
   layout: "condensed_header, diff, files"
   require_changes: true
-
-ignore:
-  - "crates/integration_tests"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "condensed_header, diff, files"
+  require_changes: true
+
+ignore:
+  - "crates/integration_tests"


### PR DESCRIPTION
- New `Coverage` workflow: cargo-llvm-cov (lcov) over the workspace against prebuilt PHP 8.5 ZTS, uploaded with `codecov/codecov-action@v5` via OIDC (`id-token: write` scoped to the job; tokenless fallback on fork PRs)
- Coverage excludes non-product code: the `integration_tests` harness, bindgen-generated `bindings.rs`, and the root `src/main.rs` stub
- `codecov.yml`: informational-only project/patch statuses, condensed PR comment
- Codecov badge in the README
- `make coverage` target for local runs, coverage artifacts gitignored