### PR TITLE
fix: use fastcgi as a fake sapi name for <= php84

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           # keep in sync with ci/php-configure-flags.txt
-          extensions: ctype, curl, dom, fileinfo, filter, iconv, mbstring, openssl, pdo_sqlite, phar, session, simplexml, sqlite3, tokenizer, xml, xmlreader, xmlwriter, zlib
+          extensions: ctype, curl, dom, fileinfo, filter, iconv, mbstring, opcache, openssl, pdo_sqlite, phar, session, simplexml, sqlite3, tokenizer, xml, xmlreader, xmlwriter, zlib
         env:
           phpts: nts
           fail-fast: true # a missing extension fails the job instead of warning

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Rapira - PHP application server. Embeds NTS PHP via the embed SAPI and serves HT
 - C compiler and `pkg-config` (the build compiles `wrapper.c`/`module.c` against the PHP headers)
 - libclang for bindgen (`libclang-dev` on Debian/Ubuntu, `clang-devel` on Fedora, `clang` on Arch)
 - PHP 8.4 or 8.5, NTS, built with the embed SAPI (`--enable-embed=shared`, provides `libphp.so`; `libphp.dylib` on macOS). ZTS builds are rejected at compile time. `ci/php-configure-flags.txt` has the full configure line used for release builds.
+- On 8.4 builds the SAPI registers itself as `fastcgi`, because OPcache on that version starts only for a fixed list of SAPI names; `PHP_SAPI` and `php_sapi_name()` report `rapira` on 8.5+. phpinfo's *Server API* row reads `Rapira` on both.
 
 Install PHP with the embed SAPI from your package manager:
 

--- a/crates/integration_tests/fixtures/php_ext/opcache-worker.php
+++ b/crates/integration_tests/fixtures/php_ext/opcache-worker.php
@@ -1,0 +1,16 @@
+<?php
+$handler = static function (): void {
+	if (!extension_loaded('Zend OPcache')) {
+		echo 'skip';
+		return;
+	}
+	// opcache_get_status() is registered whether or not accel_startup() succeeded,
+	// and returns false when it did not — so this distinguishes the two states.
+	$status = opcache_get_status(false);
+	echo is_array($status) && ($status['opcache_enabled'] ?? false)
+		? 'opcache:enabled'
+		: 'opcache:disabled';
+};
+$http = Rapira\create_plugin_handler(new Rapira\Plugin\Http\HttpHandlerConfig());
+while ($http->handleRequest($handler)) {
+}

--- a/crates/integration_tests/tests/php_ext_tests.rs
+++ b/crates/integration_tests/tests/php_ext_tests.rs
@@ -207,3 +207,10 @@ fn filter_success() -> anyhow::Result<()> {
 fn filter_exception() -> anyhow::Result<()> {
     exception("php_ext/filter-worker.php", "filter:a@b.com")
 }
+
+// No `exception` counterpart: this guards that OPcache actually started under our SAPI
+// name, which PHP <= 8.4 gates on an allowlist (see build_sapi_module). Nothing to throw.
+#[test]
+fn opcache_success() -> anyhow::Result<()> {
+    success("php_ext/opcache-worker.php", "opcache:enabled")
+}

--- a/crates/php_sys/build.rs
+++ b/crates/php_sys/build.rs
@@ -18,6 +18,7 @@ struct PhpBuild {
 }
 
 fn main() -> anyhow::Result<()> {
+    println!("cargo:rustc-check-cfg=cfg(php84)");
     println!("cargo:rustc-check-cfg=cfg(php85)");
     println!("cargo:rerun-if-env-changed=PATH");
     println!("cargo:rerun-if-env-changed=PHP_CONFIG");
@@ -29,8 +30,12 @@ fn main() -> anyhow::Result<()> {
     }
     println!("cargo:rustc-link-lib=dylib=php");
 
+    // `php84` covers every version below 8.5, not just 8.4: those are the ones whose
+    // OPcache gates startup on a SAPI-name allowlist (see build_sapi_module).
     if php.version >= (8, 5) {
         println!("cargo:rustc-cfg=php85");
+    } else {
+        println!("cargo:rustc-cfg=php84");
     }
 
     let mut c = cc::Build::new();

--- a/crates/php_sys/src/module.rs
+++ b/crates/php_sys/src/module.rs
@@ -7,6 +7,14 @@ use std::{
 
 pub(crate) fn build_sapi_module() -> sapi_module_struct {
     sapi_module_struct {
+        // OPcache <= 8.4 starts only for SAPI names on accel_find_sapi()'s allowlist; an
+        // unlisted name leaves accel_startup_ok false, so the pre-fork MINIT never creates
+        // the SHM. "fastcgi" is on that allowlist and is referenced nowhere else in php-src.
+        // 8.5 removed the allowlist:
+        // https://github.com/php/php-src/commit/3088d6406847dd425dd43122f5de57cc97aa4408
+        #[cfg(php84)]
+        name: c"fastcgi".as_ptr() as *mut c_char,
+        #[cfg(not(php84))]
         name: c"rapira".as_ptr() as *mut c_char,
         pretty_name: c"Rapira".as_ptr() as *mut c_char,
         startup: Some(callbacks::sapi_startup_cb),


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/rapira-rs/rapira/issues/43

## Description of Changes

- Use `fastcgi` as a fake SAPI name for PHP versions below 8.5 (8.4 and less).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.