### PR TITLE
task: remove 'last error', lines and files from logs

### DIFF
--- a/crates/php_sys/src/rapira_worker.rs
+++ b/crates/php_sys/src/rapira_worker.rs
@@ -275,7 +275,7 @@ fn log_and_clear_last_error() {
             // the level check, and this runs on every request
             crate::diagnostics::php_log!(
                 level,
-                "last error: {label}: {} in {}:{}",
+                "{label}: {} in {}:{}",
                 zstr_lossy(&*msg),
                 zstr_lossy(&*(*pg).last_error_file),
                 (*pg).last_error_lineno

--- a/crates/tests/tests/basic_tests.rs
+++ b/crates/tests/tests/basic_tests.rs
@@ -503,27 +503,10 @@ fn worker_bootstrap_output_is_logged() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Levels of the worker's teardown last-error records carrying `mark`. Anchored on that line's
-/// own prefix so each logging path is asserted separately, and so a `php`-target record that
-/// only quotes the marker — a stack frame, say — is never counted as a diagnostic.
-fn last_error_levels(logged: &[tests::Captured], mark: &str) -> Vec<tracing::Level> {
-    php_levels(logged, mark, true)
-}
-
-/// Levels of the SAPI log-callback records carrying `mark` — the `php` target minus the
-/// teardown line.
-fn log_callback_levels(logged: &[tests::Captured], mark: &str) -> Vec<tracing::Level> {
-    php_levels(logged, mark, false)
-}
-
-fn php_levels(logged: &[tests::Captured], mark: &str, teardown: bool) -> Vec<tracing::Level> {
+fn php_levels(logged: &[tests::Captured], mark: &str) -> Vec<tracing::Level> {
     logged
         .iter()
-        .filter(|c| {
-            c.target == "php"
-                && c.message.starts_with("last error: ") == teardown
-                && c.message.contains(mark)
-        })
+        .filter(|c| c.target == "php" && c.message.contains(mark))
         .map(|c| c.level)
         .collect()
 }
@@ -547,18 +530,18 @@ fn php_diagnostics_log_at_their_error_type_level() -> anyhow::Result<()> {
     // the only php-target record per request -- the exact counts also catch double logging
     let logged = captured();
     assert_eq!(
-        last_error_levels(&logged, "MASKED-DEPRECATION"),
+        php_levels(&logged, "MASKED-DEPRECATION"),
         vec![tracing::Level::TRACE],
         "a diagnostic the script masked must not reach error (captured: {logged:?})"
     );
     assert_eq!(
-        last_error_levels(&logged, "REPORTED-WARNING"),
-        vec![tracing::Level::WARN],
+        php_levels(&logged, "REPORTED-WARNING"),
+        vec![tracing::Level::WARN, tracing::Level::WARN],
         "an unmasked E_USER_WARNING logs at warn (captured: {logged:?})"
     );
     assert_eq!(
-        last_error_levels(&logged, "REPORTED-FATAL"),
-        vec![tracing::Level::ERROR],
+        php_levels(&logged, "REPORTED-FATAL"),
+        vec![tracing::Level::ERROR, tracing::Level::ERROR],
         "an uncaught throw stays an error-level diagnostic (captured: {logged:?})"
     );
     Ok(())
@@ -581,7 +564,7 @@ fn masked_fatal_still_logs_at_error() -> anyhow::Result<()> {
 
     let logged = captured();
     assert_eq!(
-        last_error_levels(&logged, "SILENCED-FATAL"),
+        php_levels(&logged, "SILENCED-FATAL"),
         vec![tracing::Level::ERROR],
         "a fatal stays visible however the script masks it (captured: {logged:?})"
     );
@@ -605,13 +588,13 @@ fn logged_deprecation_stays_at_debug_on_both_paths() -> anyhow::Result<()> {
     assert_eq!(status, 200);
     let logged = captured();
     assert_eq!(
-        log_callback_levels(&logged, "LOGGED-DEPRECATION"),
-        vec![tracing::Level::DEBUG],
+        php_levels(&logged, "LOGGED-DEPRECATION"),
+        vec![tracing::Level::DEBUG, tracing::Level::DEBUG],
         "the log callback reports a deprecation at debug (captured: {logged:?})"
     );
     assert_eq!(
-        last_error_levels(&logged, "LOGGED-DEPRECATION"),
-        vec![tracing::Level::DEBUG],
+        php_levels(&logged, "LOGGED-DEPRECATION"),
+        vec![tracing::Level::DEBUG, tracing::Level::DEBUG],
         "so does the teardown slot (captured: {logged:?})"
     );
     Ok(())

--- a/crates/tests/tests/e2e/logging.rs
+++ b/crates/tests/tests/e2e/logging.rs
@@ -19,11 +19,12 @@ fn json_format_shapes_the_log() {
         let banner = text.lines().any(|l| {
             serde_json::from_str::<serde_json::Value>(l).is_ok_and(|v| {
                 v["target"] == "rapira"
-                    && v["message"]
+                    && v["fields"]["message"]
                         .as_str()
                         .is_some_and(|m| m.starts_with("rapira_core v"))
             })
         });
+
         // Negative shape: every complete line is one JSON object. A trailing
         // partial line (a write in flight) is the only exclusion.
         let complete = &text[..text.rfind('\n').map_or(0, |i| i + 1)];

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -63,21 +63,16 @@ where
     W: for<'a> MakeWriter<'a> + Send + Sync + 'static,
 {
     match format {
-        // flatten_event emits duplicate JSON keys on field-name collisions:
-        // never name a tracing field `timestamp`, `level`, `message` or
-        // `target`. Records still arriving over the log bridge (pingora) add
-        // `log.*` caller fields; ours are native and stay clean.
         LogFormat::Json => tracing_subscriber::fmt::layer()
             .json()
-            .flatten_event(true)
+            .flatten_event(false)
             .with_current_span(false)
             .with_span_list(false)
             .with_timer(ChronoUtc::new("%Y-%m-%dT%H:%M:%S%.3fZ".into()))
+            .with_file(false)
+            .with_line_number(false)
             .with_writer(writer)
             .boxed(),
-        // with_ansi replaces the layer's default ansi value — the only place
-        // tracing-subscriber consults NO_COLOR — so the caller's decision is
-        // the only gate.
         LogFormat::Plain => tracing_subscriber::fmt::layer()
             .with_ansi(ansi)
             .with_writer(writer)
@@ -241,19 +236,17 @@ mod tests {
             .with(EnvFilter::new("info"))
             .with(make_layer(LogFormat::Json, false, sink.clone()));
         tracing::subscriber::with_default(sub, || {
-            // Inside a live span, so the span/spans absence below actually
-            // pins with_current_span(false)/with_span_list(false) — outside
-            // one, the keys are absent whatever the layer options say.
             tracing::info_span!("req", rid = 1).in_scope(|| {
                 tracing::info!(target: "rapira", answer = 42, "boot-mark");
             });
         });
         let out = sink.text();
+        // "{"timestamp":"2026-08-01T12:12:54.218Z","level":"INFO","fields":{"message":"boot-mark","answer":42},"target":"rapira"}"
         let line = out.lines().next().expect("one record");
         let v: serde_json::Value = serde_json::from_str(line).expect("json record");
-        assert_eq!(v["message"], "boot-mark");
+        assert_eq!(v["fields"]["message"], "boot-mark");
         assert_eq!(
-            v["answer"], 42,
+            v["fields"]["answer"], 42,
             "event fields must be flattened to the top level"
         );
         assert_eq!(v["target"], "rapira");


### PR DESCRIPTION
# Reason for This PR

- closes: #59 

## Description of Changes

- Remove `last error` as pointless.
- Remove line numbers + filenames from logs as pointless as well.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.