### PR TITLE
fix: register shutdown functions (boot) once

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -10,6 +10,11 @@ Extensions reach PHP through the `extension_api` `Php` bridge.
   Use short sentences, active voice, approved vocabulary, and one instruction per sentence.
   Avoid idioms, slang, and unnecessary synonyms. Don't write poems in the code comments.
 
+## Other
+
+- If you're trying to fix something, look at it realistically. Instead of producing a bunch of code for the case
+  which is barely possible or possible by misuse - document that, but not fix. You can also mention this in the review.
+
 ## Settled, do not reopen
 
 - NTS only, `build.rs` rejects ZTS. Unix only.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex 2.0.1",
@@ -204,7 +204,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -227,9 +227,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "equivalent"
@@ -518,9 +518,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "matchers"
@@ -818,7 +818,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -905,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -974,7 +974,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/crates/php_sys/module.c
+++ b/crates/php_sys/module.c
@@ -416,7 +416,9 @@ void rapira_clear_last_error(void) {
         }
     }
 #if PHP_VERSION_ID >= 80500
-    // the captured trace pins request objects; only shutdown_executor frees it
+    // the captured trace pins request objects; only shutdown_executor frees it.
+    // the dtor is valid only inside a live request; after php_request_shutdown,
+    // rapira_request_shutdown scrubs the stale zval instead
     zend_try {
         zval_ptr_dtor(&EG(last_fatal_error_backtrace));
         ZVAL_UNDEF(&EG(last_fatal_error_backtrace));
@@ -464,9 +466,7 @@ void rapira_release_temporary_streams(void) {
     ZEND_HASH_FOREACH_END();
 }
 
-// Boot-registered shutdown functions run once, at cycle end. The stash keeps
-// them out of the per-job calls in rapira_run_handler. Request memory: the
-// cycle is one PHP request, so the pointer stays valid.
+// Boot-registered shutdown functions run once, at cycle end.
 static HashTable *rapira_boot_shutdown_functions = NULL;
 
 void rapira_stash_boot_shutdown_functions(void) {
@@ -474,9 +474,6 @@ void rapira_stash_boot_shutdown_functions(void) {
     BG(user_shutdown_function_names) = NULL;
 }
 
-// Restore before php_request_shutdown so its own pass runs the boot functions.
-// Post-loop registrations go behind the boot entries; the buckets change owner,
-// so destroy the late table with its dtor cleared (basic_functions.c:1589).
 static void rapira_restore_boot_shutdown_functions(void) {
     HashTable *boot = rapira_boot_shutdown_functions;
     if (!boot) {
@@ -489,7 +486,9 @@ static void rapira_restore_boot_shutdown_functions(void) {
         zend_string *key = NULL;
         zval *entry = NULL;
         ZEND_HASH_FOREACH_STR_KEY_VAL(late, key, entry) {
-            // register_user_shutdown_function() entries carry a string key
+            // only register_user_shutdown_function() keys by name
+            // (ext/session); userland register_shutdown_function() appends with
+            // a numeric key
             if (key) {
                 zend_hash_update(boot, key, entry);
             } else {
@@ -498,8 +497,7 @@ static void rapira_restore_boot_shutdown_functions(void) {
         }
         ZEND_HASH_FOREACH_END();
         late->pDestructor = NULL;
-        zend_hash_destroy(late);
-        FREE_HASHTABLE(late);
+        php_free_shutdown_functions();
     }
     BG(user_shutdown_function_names) = boot;
 }
@@ -507,22 +505,33 @@ static void rapira_restore_boot_shutdown_functions(void) {
 // retry is safe: end_all NULLs EG(current_observed_frame) (zend_observer.c:322)
 int rapira_request_shutdown(void) {
     volatile int bailed = OK;
-    // put the budget back: a stale 0 disables max_execution_time next cycle
+    // put the budget back armed: a stale 0 disables max_execution_time next
+    // cycle, and the boot shutdown functions run under the timer until
+    // php_request_shutdown disarms it (main/main.c:1993)
     if (rapira_job_timeout >= 0) {
-        EG(timeout_seconds) = rapira_job_timeout;
+        zend_set_timeout(rapira_job_timeout, false);
     }
     rapira_job_timeout = -1; // cycle over: next cycle re-captures its budget
-    rapira_restore_boot_shutdown_functions();
 #ifdef HAVE_PHP_SESSION
     // left set, it makes RSHUTDOWN skip the handler's close() (mod_user.c:29)
     PS(in_save_handler) = false;
 #endif
-    zend_try { php_request_shutdown(NULL); }
+    // the restore sits inside the try: its hash inserts allocate, and a bailout
+    // with no jump target set is exit(-1) (zend.c:1258)
+    zend_try {
+        rapira_restore_boot_shutdown_functions();
+        php_request_shutdown(NULL);
+    }
     zend_catch {
         bailed = BAILOUT;
         zend_try { php_request_shutdown(NULL); }
         zend_end_try();
     }
     zend_end_try();
+#if PHP_VERSION_ID >= 80500
+    // fast shutdown skips the backtrace release (zend_execute_API.c:282,309)
+    // and the arena free reclaimed it; drop the stale zval without a dtor
+    ZVAL_UNDEF(&EG(last_fatal_error_backtrace));
+#endif
     return bailed;
 }

--- a/crates/php_sys/module.c
+++ b/crates/php_sys/module.c
@@ -464,6 +464,46 @@ void rapira_release_temporary_streams(void) {
     ZEND_HASH_FOREACH_END();
 }
 
+// Boot-registered shutdown functions run once, at cycle end. The stash keeps
+// them out of the per-job calls in rapira_run_handler. Request memory: the
+// cycle is one PHP request, so the pointer stays valid.
+static HashTable *rapira_boot_shutdown_functions = NULL;
+
+void rapira_stash_boot_shutdown_functions(void) {
+    rapira_boot_shutdown_functions = BG(user_shutdown_function_names);
+    BG(user_shutdown_function_names) = NULL;
+}
+
+// Restore before php_request_shutdown so its own pass runs the boot functions.
+// Post-loop registrations go behind the boot entries; the buckets change owner,
+// so destroy the late table with its dtor cleared (basic_functions.c:1589).
+static void rapira_restore_boot_shutdown_functions(void) {
+    HashTable *boot = rapira_boot_shutdown_functions;
+    if (!boot) {
+        return;
+    }
+    rapira_boot_shutdown_functions = NULL;
+
+    HashTable *late = BG(user_shutdown_function_names);
+    if (late) {
+        zend_string *key = NULL;
+        zval *entry = NULL;
+        ZEND_HASH_FOREACH_STR_KEY_VAL(late, key, entry) {
+            // register_user_shutdown_function() entries carry a string key
+            if (key) {
+                zend_hash_update(boot, key, entry);
+            } else {
+                zend_hash_next_index_insert(boot, entry);
+            }
+        }
+        ZEND_HASH_FOREACH_END();
+        late->pDestructor = NULL;
+        zend_hash_destroy(late);
+        FREE_HASHTABLE(late);
+    }
+    BG(user_shutdown_function_names) = boot;
+}
+
 // retry is safe: end_all NULLs EG(current_observed_frame) (zend_observer.c:322)
 int rapira_request_shutdown(void) {
     volatile int bailed = OK;
@@ -472,6 +512,7 @@ int rapira_request_shutdown(void) {
         EG(timeout_seconds) = rapira_job_timeout;
     }
     rapira_job_timeout = -1; // cycle over: next cycle re-captures its budget
+    rapira_restore_boot_shutdown_functions();
 #ifdef HAVE_PHP_SESSION
     // left set, it makes RSHUTDOWN skip the handler's close() (mod_user.c:29)
     PS(in_save_handler) = false;

--- a/crates/php_sys/rapira.stub.php
+++ b/crates/php_sys/rapira.stub.php
@@ -109,6 +109,8 @@ namespace Rapira {
     /**
      * Hand one job to $handler, which reads the superglobals and responds through
      * echo/header(). False means the worker is draining: exit the loop.
+     * Call it only from the boot script's top level; a call from a shutdown
+     * function or a destructor is undefined.
      *
      * @throws Exception\NotInWorkerModeError Called outside worker mode.
      */

--- a/crates/php_sys/src/lib.rs
+++ b/crates/php_sys/src/lib.rs
@@ -48,6 +48,8 @@ unsafe extern "C" {
     pub fn rapira_process_init();
     pub fn rapira_child_init();
     pub fn rapira_release_temporary_streams();
+    // Holds boot-registered shutdown functions until cycle end (module.c).
+    pub fn rapira_stash_boot_shutdown_functions();
     pub fn rapira_request_activate() -> c_int;
     pub fn rapira_request_shutdown() -> c_int;
     // Wall timer is disarmed while parked in receive() and re-armed with the captured per-cycle budget on unit handout (module.c).

--- a/crates/php_sys/src/rapira_worker.rs
+++ b/crates/php_sys/src/rapira_worker.rs
@@ -229,6 +229,8 @@ fn next_job() -> Option<Job> {
                 wc.recycle = true;
                 return None;
             }
+            // boot-registered shutdown functions run at cycle end
+            unsafe { rapira_stash_boot_shutdown_functions() };
             sb_update(scoreboard::Event::Healthy);
         }
         log_and_clear_last_error();

--- a/crates/php_sys/src/rapira_worker.rs
+++ b/crates/php_sys/src/rapira_worker.rs
@@ -229,7 +229,7 @@ fn next_job() -> Option<Job> {
                 wc.recycle = true;
                 return None;
             }
-            // boot-registered shutdown functions run at cycle end
+            // hide boot registrations from the per-job shutdown pass; they run at cycle end
             unsafe { rapira_stash_boot_shutdown_functions() };
             sb_update(scoreboard::Event::Healthy);
         }

--- a/crates/php_sys/wrapper.h
+++ b/crates/php_sys/wrapper.h
@@ -34,6 +34,7 @@ php_core_globals *rapira_pg(void);
 void rapira_init_call_stack(void);
 void rapira_process_init(void);
 void rapira_release_temporary_streams(void);
+void rapira_stash_boot_shutdown_functions(void);
 int rapira_request_activate(void);
 int rapira_request_shutdown(void);
 size_t rapira_ub_write(const char *str, size_t len);

--- a/crates/tests/fixtures/ported_tests/boot-global-worker.php
+++ b/crates/tests/fixtures/ported_tests/boot-global-worker.php
@@ -1,0 +1,28 @@
+<?php
+// A refcount-1 object in a bare boot global stays in the symbol table across jobs. Its destructor runs once, at cycle end.
+class Kernel
+{
+    public int $calls = 0;
+
+    public function tick(): int
+    {
+        return ++$this->calls;
+    }
+
+    public function __destruct()
+    {
+        \Rapira\log('boot-kernel destructed');
+    }
+}
+
+$kernel = new Kernel();
+
+$handler = static function (): void {
+    if (!isset($GLOBALS['kernel'])) {
+        echo 'kernel=gone';
+        return;
+    }
+    echo 'kernel=ok calls=', $GLOBALS['kernel']->tick();
+};
+while (\Rapira\handle_request($handler)) {
+}

--- a/crates/tests/fixtures/ported_tests/boot-shutdown-worker.php
+++ b/crates/tests/fixtures/ported_tests/boot-shutdown-worker.php
@@ -1,0 +1,13 @@
+<?php
+// A boot-registered shutdown function runs once, at cycle end.
+$fired = 0;
+register_shutdown_function(static function () use (&$fired): void {
+    $fired++;
+    \Rapira\log('boot-shutdown fired=' . $fired);
+});
+
+$handler = static function () use (&$fired): void {
+    echo 'fired=', $fired;
+};
+while (\Rapira\handle_request($handler)) {
+}

--- a/crates/tests/fixtures/ported_tests/job-shutdown-worker.php
+++ b/crates/tests/fixtures/ported_tests/job-shutdown-worker.php
@@ -4,6 +4,7 @@ $bootFired = 0;
 $jobFired = 0;
 register_shutdown_function(static function () use (&$bootFired): void {
     $bootFired++;
+    \Rapira\log('job-fixture boot fired=' . $bootFired);
 });
 
 $req = 0;
@@ -12,6 +13,7 @@ $handler = static function () use (&$jobFired, &$req, &$bootFired): void {
     if ($req === 1) {
         register_shutdown_function(static function () use (&$jobFired): void {
             $jobFired++;
+            \Rapira\log('job-fixture job fired=' . $jobFired);
         });
     }
     echo 'req=', $req, ' job_fired=', $jobFired, ' boot_fired=', $bootFired;

--- a/crates/tests/fixtures/ported_tests/job-shutdown-worker.php
+++ b/crates/tests/fixtures/ported_tests/job-shutdown-worker.php
@@ -1,0 +1,20 @@
+<?php
+// A shutdown function registered during a job runs at the end of that job, exactly once. The boot-registered one runs at cycle end.
+$bootFired = 0;
+$jobFired = 0;
+register_shutdown_function(static function () use (&$bootFired): void {
+    $bootFired++;
+});
+
+$req = 0;
+$handler = static function () use (&$jobFired, &$req, &$bootFired): void {
+    $req++;
+    if ($req === 1) {
+        register_shutdown_function(static function () use (&$jobFired): void {
+            $jobFired++;
+        });
+    }
+    echo 'req=', $req, ' job_fired=', $jobFired, ' boot_fired=', $bootFired;
+};
+while (\Rapira\handle_request($handler)) {
+}

--- a/crates/tests/fixtures/ported_tests/late-shutdown-worker.php
+++ b/crates/tests/fixtures/ported_tests/late-shutdown-worker.php
@@ -1,0 +1,16 @@
+<?php
+// Two boot registrations, one post-loop registration: cycle end runs the boot entries first, then the late one.
+register_shutdown_function(static function (): void {
+    \Rapira\log('sd boot-a');
+});
+register_shutdown_function(static function (): void {
+    \Rapira\log('sd boot-b');
+});
+$handler = static function (): void {
+    echo 'ok';
+};
+while (\Rapira\handle_request($handler)) {
+}
+register_shutdown_function(static function (): void {
+    \Rapira\log('sd late');
+});

--- a/crates/tests/fixtures/ported_tests/shutdown-fatal-boot-worker.php
+++ b/crates/tests/fixtures/ported_tests/shutdown-fatal-boot-worker.php
@@ -1,0 +1,10 @@
+<?php
+// A fatal inside a boot shutdown function must leave the worker's exit path clean.
+register_shutdown_function(static function (): void {
+    trigger_error('boot shutdown bomb', E_USER_ERROR); // absorbed by php_call_shutdown_functions' zend_try
+});
+$handler = static function (): void {
+    echo 'ok';
+};
+while (\Rapira\handle_request($handler)) {
+}

--- a/crates/tests/tests/ported_tests.rs
+++ b/crates/tests/tests/ported_tests.rs
@@ -832,7 +832,11 @@ fn boot_global_object_survives_requests() -> anyhow::Result<()> {
     let _guard = php_lock();
     let r = Rapira::start(Mode::Worker(fixture("ported_tests/boot-global-worker.php")))?;
     let h = r.handle();
-    for want in ["kernel=ok calls=1", "kernel=ok calls=2", "kernel=ok calls=3"] {
+    for want in [
+        "kernel=ok calls=1",
+        "kernel=ok calls=2",
+        "kernel=ok calls=3",
+    ] {
         let (status, body) = drain(h.handle_blocking(req(
             "/boot-global-worker.php",
             "ported_tests/boot-global-worker.php",

--- a/crates/tests/tests/ported_tests.rs
+++ b/crates/tests/tests/ported_tests.rs
@@ -1,7 +1,7 @@
 use std::{ops::Deref, path::Path};
 
 use php_sys::{Frame, Mode, Rapira, Request};
-use tests::{drain, fixture, php_lock, req};
+use tests::{captured, drain, fixture, init_log_capture, php_lock, req};
 
 fn post(fixture_name: &str, query: &str, content_type: Option<&str>, body: Vec<u8>) -> Request {
     let mut r: Request = req(&format!("/{fixture_name}?{query}"), fixture_name);
@@ -752,6 +752,130 @@ fn throwing_destructor_after_job_stays_contained_worker() -> anyhow::Result<()> 
         (s2, b2.as_str()),
         (200, "served=2"),
         "the cycle must survive a throwing post-job destructor"
+    );
+    Ok(())
+}
+
+/// A boot-registered shutdown function runs once, at cycle end.
+#[test]
+fn boot_shutdown_function_fires_once_at_worker_exit() -> anyhow::Result<()> {
+    let _guard = php_lock();
+    init_log_capture();
+    captured().clear();
+
+    let r = Rapira::start(Mode::Worker(fixture(
+        "ported_tests/boot-shutdown-worker.php",
+    )))?;
+    let h = r.handle();
+    for _ in 0..2 {
+        let (status, body) = drain(h.handle_blocking(req(
+            "/boot-shutdown-worker.php",
+            "ported_tests/boot-shutdown-worker.php",
+        ))?);
+        assert_eq!(status, 200);
+        assert_eq!(
+            body, "fired=0",
+            "a boot-registered shutdown function must not run at a job's end"
+        );
+    }
+
+    let fires = |records: &[tests::Captured]| {
+        records
+            .iter()
+            .filter(|c| c.target == "app" && c.message.starts_with("boot-shutdown fired="))
+            .map(|c| c.message.clone())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        fires(&captured()),
+        Vec::<String>::new(),
+        "the boot function must not run while jobs are served"
+    );
+
+    drop(h);
+    r.shutdown();
+    assert_eq!(
+        fires(&captured()),
+        vec!["boot-shutdown fired=1".to_owned()],
+        "the boot-registered shutdown function must fire exactly once, at worker exit"
+    );
+    Ok(())
+}
+
+/// A shutdown function registered during a job runs at the end of that job, exactly once.
+#[test]
+fn job_shutdown_function_fires_at_end_of_its_job() -> anyhow::Result<()> {
+    let _guard = php_lock();
+    let r = Rapira::start(Mode::Worker(fixture(
+        "ported_tests/job-shutdown-worker.php",
+    )))?;
+    let h = r.handle();
+    for want in [
+        "req=1 job_fired=0 boot_fired=0",
+        "req=2 job_fired=1 boot_fired=0",
+        "req=3 job_fired=1 boot_fired=0",
+    ] {
+        let (status, body) = drain(h.handle_blocking(req(
+            "/job-shutdown-worker.php",
+            "ported_tests/job-shutdown-worker.php",
+        ))?);
+        assert_eq!((status, body.as_str()), (200, want));
+    }
+    drop(h);
+    r.shutdown();
+    Ok(())
+}
+
+/// A refcount-1 object in a bare boot-level global must stay in the symbol table across jobs.
+#[test]
+fn boot_global_object_survives_requests() -> anyhow::Result<()> {
+    let _guard = php_lock();
+    let r = Rapira::start(Mode::Worker(fixture("ported_tests/boot-global-worker.php")))?;
+    let h = r.handle();
+    for want in ["kernel=ok calls=1", "kernel=ok calls=2", "kernel=ok calls=3"] {
+        let (status, body) = drain(h.handle_blocking(req(
+            "/boot-global-worker.php",
+            "ported_tests/boot-global-worker.php",
+        ))?);
+        assert_eq!((status, body.as_str()), (200, want));
+    }
+    drop(h);
+    r.shutdown();
+    Ok(())
+}
+
+/// A boot object's __destruct runs once, at cycle end.
+#[test]
+fn boot_object_destructor_fires_once_at_worker_exit() -> anyhow::Result<()> {
+    let _guard = php_lock();
+    init_log_capture();
+    captured().clear();
+
+    let r = Rapira::start(Mode::Worker(fixture("ported_tests/boot-global-worker.php")))?;
+    let h = r.handle();
+    for _ in 0..2 {
+        let (status, body) = drain(h.handle_blocking(req(
+            "/boot-global-worker.php",
+            "ported_tests/boot-global-worker.php",
+        ))?);
+        assert_eq!(status, 200);
+        assert!(body.starts_with("kernel=ok"), "got {body:?}");
+    }
+
+    let dtors = |records: &[tests::Captured]| {
+        records
+            .iter()
+            .filter(|c| c.target == "app" && c.message == "boot-kernel destructed")
+            .count()
+    };
+    assert_eq!(dtors(&captured()), 0, "no __destruct while jobs are served");
+
+    drop(h);
+    r.shutdown();
+    assert_eq!(
+        dtors(&captured()),
+        1,
+        "the boot object must destruct exactly once, at worker exit"
     );
     Ok(())
 }

--- a/crates/tests/tests/ported_tests.rs
+++ b/crates/tests/tests/ported_tests.rs
@@ -55,6 +55,15 @@ fn header_value(r: &Resp, name: &str) -> Option<String> {
         .map(|(_, v)| String::from_utf8_lossy(v).into_owned())
 }
 
+/// The captured `app`-target messages starting with `prefix`, in order.
+fn app_messages(prefix: &str) -> Vec<String> {
+    captured()
+        .iter()
+        .filter(|c| c.target == "app" && c.message.starts_with(prefix))
+        .map(|c| c.message.clone())
+        .collect()
+}
+
 /// POST form body parses into $_POST while the query string populates $_GET.
 #[test]
 fn post_superglobals_classic() -> anyhow::Result<()> {
@@ -779,33 +788,29 @@ fn boot_shutdown_function_fires_once_at_worker_exit() -> anyhow::Result<()> {
         );
     }
 
-    let fires = |records: &[tests::Captured]| {
-        records
-            .iter()
-            .filter(|c| c.target == "app" && c.message.starts_with("boot-shutdown fired="))
-            .map(|c| c.message.clone())
-            .collect::<Vec<_>>()
-    };
     assert_eq!(
-        fires(&captured()),
+        app_messages("boot-shutdown fired="),
         Vec::<String>::new(),
-        "the boot function must not run while jobs are served"
+        "the boot function must not run while the worker serves jobs"
     );
 
     drop(h);
     r.shutdown();
     assert_eq!(
-        fires(&captured()),
+        app_messages("boot-shutdown fired="),
         vec!["boot-shutdown fired=1".to_owned()],
         "the boot-registered shutdown function must fire exactly once, at worker exit"
     );
     Ok(())
 }
 
-/// A shutdown function registered during a job runs at the end of that job, exactly once.
+/// A shutdown function registered during a job runs at the end of that job, exactly once. The boot-registered one fires once, at cycle end.
 #[test]
 fn job_shutdown_function_fires_at_end_of_its_job() -> anyhow::Result<()> {
     let _guard = php_lock();
+    init_log_capture();
+    captured().clear();
+
     let r = Rapira::start(Mode::Worker(fixture(
         "ported_tests/job-shutdown-worker.php",
     )))?;
@@ -821,15 +826,100 @@ fn job_shutdown_function_fires_at_end_of_its_job() -> anyhow::Result<()> {
         ))?);
         assert_eq!((status, body.as_str()), (200, want));
     }
+
+    assert_eq!(
+        app_messages("job-fixture "),
+        vec!["job-fixture job fired=1".to_owned()],
+        "only the job-registered function runs while the worker serves jobs"
+    );
+
     drop(h);
     r.shutdown();
+    assert_eq!(
+        app_messages("job-fixture "),
+        vec![
+            "job-fixture job fired=1".to_owned(),
+            "job-fixture boot fired=1".to_owned(),
+        ],
+        "at worker exit the boot function fires once and the job function does not run again"
+    );
     Ok(())
 }
 
-/// A refcount-1 object in a bare boot-level global must stay in the symbol table across jobs.
+/// Boot entries run first at cycle end; a post-loop registration runs after them.
+#[test]
+fn late_shutdown_function_runs_after_boot_entries() -> anyhow::Result<()> {
+    let _guard = php_lock();
+    init_log_capture();
+    captured().clear();
+
+    let r = Rapira::start(Mode::Worker(fixture(
+        "ported_tests/late-shutdown-worker.php",
+    )))?;
+    let h = r.handle();
+    for _ in 0..2 {
+        let (status, body) = drain(h.handle_blocking(req(
+            "/late-shutdown-worker.php",
+            "ported_tests/late-shutdown-worker.php",
+        ))?);
+        assert_eq!((status, body.as_str()), (200, "ok"));
+    }
+
+    assert_eq!(
+        app_messages("sd "),
+        Vec::<String>::new(),
+        "no shutdown function runs while the worker serves jobs"
+    );
+
+    drop(h);
+    r.shutdown();
+    assert_eq!(
+        app_messages("sd "),
+        vec![
+            "sd boot-a".to_owned(),
+            "sd boot-b".to_owned(),
+            "sd late".to_owned(),
+        ],
+        "cycle end runs the boot entries in registration order, then the post-loop entry"
+    );
+    Ok(())
+}
+
+/// A fatal inside a boot shutdown function leaves the worker's exit path clean.
+#[test]
+fn fatal_in_boot_shutdown_function_exits_clean() -> anyhow::Result<()> {
+    let _guard = php_lock();
+    init_log_capture();
+    captured().clear();
+
+    let r = Rapira::start(Mode::Worker(fixture(
+        "ported_tests/shutdown-fatal-boot-worker.php",
+    )))?;
+    let h = r.handle();
+    let (status, body) = drain(h.handle_blocking(req(
+        "/shutdown-fatal-boot-worker.php",
+        "ported_tests/shutdown-fatal-boot-worker.php",
+    ))?);
+    assert_eq!((status, body.as_str()), (200, "ok"));
+
+    drop(h);
+    r.shutdown();
+    assert!(
+        captured()
+            .iter()
+            .any(|c| c.message.contains("boot shutdown bomb")),
+        "the fatal from the boot shutdown function must reach the log"
+    );
+    Ok(())
+}
+
+/// A refcount-1 object in a bare boot-level global must stay in the symbol table across jobs; its __destruct runs once, at cycle end.
 #[test]
 fn boot_global_object_survives_requests() -> anyhow::Result<()> {
     let _guard = php_lock();
+    init_log_capture();
+    captured().clear();
+
     let r = Rapira::start(Mode::Worker(fixture("ported_tests/boot-global-worker.php")))?;
     let h = r.handle();
     for want in [
@@ -843,41 +933,16 @@ fn boot_global_object_survives_requests() -> anyhow::Result<()> {
         ))?);
         assert_eq!((status, body.as_str()), (200, want));
     }
-    drop(h);
-    r.shutdown();
-    Ok(())
-}
-
-/// A boot object's __destruct runs once, at cycle end.
-#[test]
-fn boot_object_destructor_fires_once_at_worker_exit() -> anyhow::Result<()> {
-    let _guard = php_lock();
-    init_log_capture();
-    captured().clear();
-
-    let r = Rapira::start(Mode::Worker(fixture("ported_tests/boot-global-worker.php")))?;
-    let h = r.handle();
-    for _ in 0..2 {
-        let (status, body) = drain(h.handle_blocking(req(
-            "/boot-global-worker.php",
-            "ported_tests/boot-global-worker.php",
-        ))?);
-        assert_eq!(status, 200);
-        assert!(body.starts_with("kernel=ok"), "got {body:?}");
-    }
-
-    let dtors = |records: &[tests::Captured]| {
-        records
-            .iter()
-            .filter(|c| c.target == "app" && c.message == "boot-kernel destructed")
-            .count()
-    };
-    assert_eq!(dtors(&captured()), 0, "no __destruct while jobs are served");
+    assert_eq!(
+        app_messages("boot-kernel destructed").len(),
+        0,
+        "no __destruct while the worker serves jobs"
+    );
 
     drop(h);
     r.shutdown();
     assert_eq!(
-        dtors(&captured()),
+        app_messages("boot-kernel destructed").len(),
         1,
         "the boot object must destruct exactly once, at worker exit"
     );


### PR DESCRIPTION
# Reason for This PR

- closes: #82 

## Description of Changes

- Save all boot destruct functions and call them only when the worker is destroyed via `BG(user_shutdown_function_names) = boot`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.