### PR TITLE
feat: static files serving (#76)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -78,3 +78,4 @@ Delete dead code and defenses against threat models that cannot occur. Already w
 - Smallest safe fix, local to the finding. No speculative hardening, no unrelated cleanup.
 - If you see other's bots comments: triage them, add to your review if they're relevant and resolve all threads.
 - Do not respond to the bots' comments.
+- Keep an eye on simplification of the changes and existing code.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -78,4 +78,4 @@ Delete dead code and defenses against threat models that cannot occur. Already w
 - Smallest safe fix, local to the finding. No speculative hardening, no unrelated cleanup.
 - If you see other's bots comments: triage them, add to your review if they're relevant and resolve all threads.
 - Do not respond to the bots' comments.
-- Keep an eye on simplification of the changes and existing code.
+- When you review a PR, check whether the changes or related existing code can be simpler without changing behavior.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,7 @@ C sources (`crates/php_sys/*.c`, `*.h`) follow `.clang-format`.
 | `crates/api`           | the native extension contract                                                       |
 | `crates/scoreboard`    | shared per-worker counters                                                          |
 | `crates/plugins/tower` | the HTTP front                                                                      |
+| `crates/middleware`    | built-in HTTP middleware, one crate per middleware                                  |
 | `crates/tests`         | integration and e2e suites                                                          |
 
 ## Pull requests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "rapira_static_files"
-version = "0.8.0"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "extension_api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
 name = "futures-task"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +372,12 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -547,6 +559,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +630,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "php_sys"
@@ -679,6 +713,7 @@ dependencies = [
  "rapira_master",
  "rapira_runtime",
  "rapira_scoreboard",
+ "rapira_static_files",
  "rapira_tower",
  "serde_json",
  "tracing",
@@ -717,6 +752,21 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "libc",
+]
+
+[[package]]
+name = "rapira_static_files"
+version = "0.8.0"
+dependencies = [
+ "bytes",
+ "extension_api",
+ "http",
+ "http-body-util",
+ "percent-encoding",
+ "tempfile",
+ "tokio",
+ "tower-http",
+ "tracing",
 ]
 
 [[package]]
@@ -958,6 +1008,7 @@ version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
@@ -975,6 +1026,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.4",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1015,6 +1079,43 @@ name = "toml_writer"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1090,6 +1191,12 @@ dependencies = [
  "tracing-log",
  "tracing-serde",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/api",
     "crates/tests",
     "crates/master",
+    "crates/middleware/static_files",
     "crates/php_sys",
     "crates/scoreboard",
     "crates/plugins/tower",
@@ -36,6 +37,7 @@ php_sys = { path = "crates/php_sys" }
 rapira_runtime = { path = "crates/runtime" }
 rapira_config = { path = "crates/config" }
 extension_api = { path = "crates/api" }
+rapira_static_files = { path = "crates/middleware/static_files" }
 rapira_tower = { path = "crates/plugins/tower" }
 rapira_master = { path = "crates/master" }
 rapira_scoreboard = { path = "crates/scoreboard" }
@@ -61,6 +63,7 @@ rapira_scoreboard = { workspace = true }
 rapira_runtime = { workspace = true }
 php_sys = { workspace = true }
 rapira_config = { workspace = true }
+rapira_static_files = { workspace = true }
 rapira_tower = { workspace = true }
 libc = "0.2"
 mimalloc = "0.1"

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 mod middleware;
 mod prepare;
 pub use middleware::{
-    Body, BoxError, BoxFuture, Handler, HttpRequest, HttpResponse, Middleware, Next, Peer, Protocol,
+    Body, BoxError, BoxFuture, Handler, HttpRequest, HttpResponse, Middleware, Next, Peer,
+    Protocol, empty_body,
 };
 pub use prepare::{LISTEN_BACKLOG, ListenAddr, PrepareCtx, PreparedListener};
 

--- a/crates/api/src/middleware.rs
+++ b/crates/api/src/middleware.rs
@@ -15,6 +15,14 @@ pub type Body = http_body_util::combinators::UnsyncBoxBody<Bytes, BoxError>;
 pub type HttpRequest = http::Request<Body>;
 pub type HttpResponse = http::Response<Body>;
 
+/// An empty [`Body`].
+pub fn empty_body() -> Body {
+    use http_body_util::BodyExt;
+    http_body_util::Empty::<Bytes>::new()
+        .map_err(BoxError::from)
+        .boxed_unsync()
+}
+
 // this will be probably only implemented in http/grpc stack
 // or more protocols will be added, like jobs, etc
 #[non_exhaustive]
@@ -75,11 +83,6 @@ impl Next {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use http_body_util::{BodyExt, Empty};
-
-    fn empty() -> Body {
-        Empty::new().map_err(|e| match e {}).boxed_unsync()
-    }
 
     struct Tag(&'static str);
 
@@ -100,7 +103,12 @@ mod tests {
 
     impl Middleware for Deny {
         fn handle<'a>(&'a self, _req: HttpRequest, _next: Next) -> BoxFuture<'a, HttpResponse> {
-            Box::pin(async { http::Response::builder().status(403).body(empty()).unwrap() })
+            Box::pin(async {
+                http::Response::builder()
+                    .status(403)
+                    .body(empty_body())
+                    .unwrap()
+            })
         }
     }
 
@@ -109,7 +117,10 @@ mod tests {
     impl Handler for Echo {
         fn call<'a>(&'a self, req: HttpRequest) -> BoxFuture<'a, HttpResponse> {
             Box::pin(async move {
-                let mut res = http::Response::builder().status(200).body(empty()).unwrap();
+                let mut res = http::Response::builder()
+                    .status(200)
+                    .body(empty_body())
+                    .unwrap();
                 for v in req.headers().get_all("x-trace") {
                     res.headers_mut().append("x-trace", v.clone());
                 }
@@ -133,7 +144,7 @@ mod tests {
             Arc::new(Tag("b")),
         ]);
         let next = Next::new(chain, Arc::new(Echo));
-        let res = next.run(http::Request::new(empty())).await;
+        let res = next.run(http::Request::new(empty_body())).await;
         assert_eq!(res.status(), 200);
         assert_eq!(trace(&res), ["a-in", "b-in", "b-out", "a-out"]);
     }
@@ -146,7 +157,7 @@ mod tests {
             Arc::new(Tag("never")),
         ]);
         let next = Next::new(chain, Arc::new(Echo));
-        let res = next.run(http::Request::new(empty())).await;
+        let res = next.run(http::Request::new(empty_body())).await;
         assert_eq!(res.status(), 403);
         assert_eq!(trace(&res), ["a-out"]);
     }
@@ -154,7 +165,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn empty_chain_reaches_the_handler_directly() {
         let next = Next::new(Arc::from(Vec::new()), Arc::new(Echo));
-        let mut req = http::Request::new(empty());
+        let mut req = http::Request::new(empty_body());
         req.headers_mut().append("x-trace", "solo".parse().unwrap());
         let res = next.run(req).await;
         assert_eq!(res.status(), 200);

--- a/crates/config/src/http.rs
+++ b/crates/config/src/http.rs
@@ -25,7 +25,8 @@ pub struct HttpSettings {
 #[derive(Debug)]
 pub struct StaticSettings {
     pub root: PathBuf,
-    /// Extensions never served from the root, lowercase with a leading dot.
+    /// Extensions the middleware never serves from the root, with a leading dot.
+    /// The middleware normalizes the case.
     pub forbid: Vec<String>,
 }
 
@@ -65,7 +66,7 @@ pub(crate) struct HttpSection {
     pub(crate) r#static: Option<StaticSection>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct StaticSection {
     pub(crate) root: Option<String>,
@@ -80,12 +81,17 @@ pub(crate) fn resolve_static(
         Some(r) => config_relative(config_dir, &r)?,
         None => bail!("http.static.root is required"),
     };
-    let mut forbid = section.forbid.unwrap_or_else(|| vec![".php".to_owned()]);
-    for entry in &mut forbid {
-        if entry.len() < 2 || !entry.starts_with('.') {
+    let forbid = section.forbid.unwrap_or_else(|| vec![".php".to_owned()]);
+    for entry in &forbid {
+        // A separator or whitespace can never suffix-match a file name. Such an entry would
+        // silently make the guard useless.
+        if entry.len() < 2
+            || !entry.starts_with('.')
+            || entry.contains('/')
+            || entry.chars().any(char::is_whitespace)
+        {
             bail!("http.static.forbid entries must be extensions with a leading dot (`{entry}`)");
         }
-        entry.make_ascii_lowercase();
     }
     Ok(StaticSettings { root, forbid })
 }

--- a/crates/config/src/http.rs
+++ b/crates/config/src/http.rs
@@ -18,6 +18,15 @@ pub struct HttpSettings {
     pub uploads: UploadSettings,
     /// `[http.sendfile].root`; None = the entrypoint's directory.
     pub sendfile_root: Option<PathBuf>,
+    /// `[http.static]`; None = static file serving off.
+    pub static_files: Option<StaticSettings>,
+}
+
+#[derive(Debug)]
+pub struct StaticSettings {
+    pub root: PathBuf,
+    /// Extensions never served from the root, lowercase with a leading dot.
+    pub forbid: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -53,6 +62,32 @@ pub(crate) struct HttpSection {
     pub(crate) uploads: Option<UploadsSection>,
     #[serde(default)]
     pub(crate) sendfile: SendfileSection,
+    pub(crate) r#static: Option<StaticSection>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct StaticSection {
+    pub(crate) root: Option<String>,
+    pub(crate) forbid: Option<Vec<String>>,
+}
+
+pub(crate) fn resolve_static(
+    section: StaticSection,
+    config_dir: Option<&Path>,
+) -> anyhow::Result<StaticSettings> {
+    let root = match section.root.filter(|r| !r.is_empty()) {
+        Some(r) => config_relative(config_dir, &r)?,
+        None => bail!("http.static.root is required"),
+    };
+    let mut forbid = section.forbid.unwrap_or_else(|| vec![".php".to_owned()]);
+    for entry in &mut forbid {
+        if entry.len() < 2 || !entry.starts_with('.') {
+            bail!("http.static.forbid entries must be extensions with a leading dot (`{entry}`)");
+        }
+        entry.make_ascii_lowercase();
+    }
+    Ok(StaticSettings { root, forbid })
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/crates/config/src/http.rs
+++ b/crates/config/src/http.rs
@@ -12,14 +12,12 @@ pub struct HttpSettings {
     pub server_port: u16,
     pub max_body_size: usize,
     pub write_timeout: std::time::Duration,
-    /// Bounds client read progress: one request-head read (including the keepalive idle wait) and each request-body frame.
     pub keepalive_timeout: std::time::Duration,
     pub unsafe_field_names: UnsafeFieldNames,
     pub uploads: UploadSettings,
-    /// `[http.sendfile].root`; None = the entrypoint's directory.
     pub sendfile_root: Option<PathBuf>,
-    /// `[http.static]`; None = static file serving off.
-    pub static_files: Option<StaticSettings>,
+    // [http].middleware list order
+    pub middleware: Vec<MiddlewareSettings>,
 }
 
 #[derive(Debug)]
@@ -59,12 +57,20 @@ pub(crate) struct HttpSection {
     pub(crate) write_timeout_secs: Option<u64>,
     pub(crate) keepalive_timeout_secs: Option<u64>,
     pub(crate) unsafe_field_names: Option<UnsafeFieldNames>,
-    /// Option so presence is observable: the table is rejected outside dispatcher mode.
     pub(crate) uploads: Option<UploadsSection>,
     #[serde(default)]
     pub(crate) sendfile: SendfileSection,
+    pub(crate) middleware: Option<Vec<String>>,
     pub(crate) r#static: Option<StaticSection>,
 }
+
+// ------------ middleware stuff ---------------
+// add new middleware here, with settings if needed
+#[derive(Debug)]
+pub enum MiddlewareSettings {
+    Static(StaticSettings),
+}
+// ---------------------------------------------
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -94,6 +100,46 @@ pub(crate) fn resolve_static(
         }
     }
     Ok(StaticSettings { root, forbid })
+}
+
+// resolve all existing vs requested middlewares
+// TODO: think about some container, like endure in RR
+pub(crate) fn resolve_middleware(
+    list: Option<Vec<String>>,
+    mut static_files: Option<StaticSettings>,
+) -> anyhow::Result<Vec<MiddlewareSettings>> {
+    let list = list.unwrap_or_default();
+
+    for (i, name) in list.iter().enumerate() {
+        if list[..i].contains(name) {
+            bail!("http.middleware lists \"{name}\" twice")
+        }
+    }
+
+    let mut middleware: Vec<MiddlewareSettings> = Vec::new();
+    for name in &list {
+        match name.as_str() {
+            // check new middleware here
+            "static" => match static_files.take() {
+                Some(settings) => middleware.push(MiddlewareSettings::Static(settings)),
+                None => {
+                    bail!("http.middleware lists \"static\" but [http.static] is missing")
+                }
+            },
+            other => {
+                bail!("http.middleware entry \"{other}\" is unknown; known middleware: \"static\"")
+            }
+        }
+    }
+
+    // check for the configured, but not listed
+    // TODO: worth double checking
+    // some people requested some kind of enabled=false/true
+    if static_files.is_some() {
+        bail!("[http.static] is configured but http.middleware does not list \"static\"");
+    }
+
+    Ok(middleware)
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -10,13 +10,15 @@ mod log;
 mod pool;
 mod supervisor;
 
-pub use http::{HttpSettings, StaticSettings, UnsafeFieldNames, UploadSettings};
+pub use http::{
+    HttpSettings, MiddlewareSettings, StaticSettings, UnsafeFieldNames, UploadSettings,
+};
 pub use listen::{Listen, ListenParseError};
 pub use log::{LogFormat, LogLevel, LogSettings};
 pub use pool::{PoolSettings, RunMode, Scaling};
 pub use supervisor::SupervisorSettings;
 
-use http::{HttpSection, resolve_static, resolve_uploads};
+use http::{HttpSection, resolve_middleware, resolve_static, resolve_uploads};
 use log::{LogSection, resolve_log};
 use pool::{PoolSection, resolve_pool};
 use supervisor::{SupervisorSection, resolve_supervisor};
@@ -132,6 +134,7 @@ fn merge(file: FileConfig, cli: Overrides, config_dir: Option<&Path>) -> anyhow:
     let uploads = resolve_uploads(file.http.uploads.unwrap_or_default(), config_dir)?;
     let supervisor = resolve_supervisor(file.supervisor, config_dir)?;
     let log = resolve_log(file.log)?;
+    let middleware = resolve_middleware(file.http.middleware, static_files)?;
 
     Ok(Settings {
         http: HttpSettings {
@@ -147,7 +150,7 @@ fn merge(file: FileConfig, cli: Overrides, config_dir: Option<&Path>) -> anyhow:
             unsafe_field_names: file.http.unsafe_field_names.unwrap_or_default(),
             uploads,
             sendfile_root,
-            static_files,
+            middleware,
         },
         pool,
         supervisor,
@@ -562,24 +565,52 @@ mod tests {
     /// The root resolves config-relative like every other path key; forbid defaults to the PHP source guard.
     #[test]
     fn http_static_resolves_with_defaults() {
-        let file =
-            load_str("[pool]\nentrypoint = \"a.php\"\n[http.static]\nroot = \"public\"\n").unwrap();
+        let file = load_str(
+            "[pool]\nentrypoint = \"a.php\"\n[http]\nmiddleware = [\"static\"]\n[http.static]\nroot = \"public\"\n",
+        )
+        .unwrap();
         let s = merge(file, Overrides::default(), Some(Path::new("/w"))).unwrap();
-        let st = s.http.static_files.expect("section present");
+        let MiddlewareSettings::Static(st) = &s.http.middleware[0];
         assert_eq!(st.root, Path::new("/w/public"));
         assert_eq!(st.forbid, vec![".php".to_owned()]);
 
         let file = load_str("[pool]\nentrypoint = \"a.php\"\n").unwrap();
         let s = merge(file, Overrides::default(), Some(Path::new("/w"))).unwrap();
-        assert!(s.http.static_files.is_none());
+        assert!(s.http.middleware.is_empty());
 
-        let file = load_str("[pool]\nentrypoint = \"a.php\"\n[http.static]\nroot = \"/srv/pub\"\n")
-            .unwrap();
+        let file = load_str(
+            "[pool]\nentrypoint = \"a.php\"\n[http]\nmiddleware = [\"static\"]\n[http.static]\nroot = \"/srv/pub\"\n",
+        )
+        .unwrap();
         let s = merge(file, Overrides::default(), Some(Path::new("/w"))).unwrap();
-        assert_eq!(
-            s.http.static_files.expect("section present").root,
-            Path::new("/srv/pub")
-        );
+        let MiddlewareSettings::Static(st) = &s.http.middleware[0];
+        assert_eq!(st.root, Path::new("/srv/pub"));
+    }
+
+    /// The list is the activation switch: every configured section must be listed, every listed name must be known, configured, and unique.
+    #[test]
+    fn http_middleware_list_validates() {
+        for (toml, needle) in [
+            (
+                "[http]\nmiddleware = [\"staticc\"]\n",
+                "\"staticc\" is unknown",
+            ),
+            (
+                "[http]\nmiddleware = [\"static\"]\n",
+                "[http.static] is missing",
+            ),
+            (
+                "[http]\nmiddleware = [\"static\", \"static\"]\n[http.static]\nroot = \"p\"\n",
+                "twice",
+            ),
+            ("[http.static]\nroot = \"p\"\n", "does not list \"static\""),
+        ] {
+            let file = load_str(&format!("[pool]\nentrypoint = \"a.php\"\n{toml}")).unwrap();
+            let err = merge(file, Overrides::default(), Some(Path::new("/w")))
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains(needle), "{toml}: {err}");
+        }
     }
 
     #[test]
@@ -603,24 +634,20 @@ mod tests {
     #[test]
     fn http_static_forbid_validates() {
         let file = load_str(
-            "[pool]\nentrypoint = \"a.php\"\n[http.static]\nroot = \"p\"\nforbid = [\".PHP\", \".Phtml\"]\n",
+            "[pool]\nentrypoint = \"a.php\"\n[http]\nmiddleware = [\"static\"]\n[http.static]\nroot = \"p\"\nforbid = [\".PHP\", \".Phtml\"]\n",
         )
         .unwrap();
         let s = merge(file, Overrides::default(), Some(Path::new("/w"))).unwrap();
-        let st = s.http.static_files.expect("section present");
+        let MiddlewareSettings::Static(st) = &s.http.middleware[0];
         assert_eq!(st.forbid, vec![".PHP".to_owned(), ".Phtml".to_owned()]);
 
-        let file =
-            load_str("[pool]\nentrypoint = \"a.php\"\n[http.static]\nroot = \"p\"\nforbid = []\n")
-                .unwrap();
+        let file = load_str(
+            "[pool]\nentrypoint = \"a.php\"\n[http]\nmiddleware = [\"static\"]\n[http.static]\nroot = \"p\"\nforbid = []\n",
+        )
+        .unwrap();
         let s = merge(file, Overrides::default(), Some(Path::new("/w"))).unwrap();
-        assert!(
-            s.http
-                .static_files
-                .expect("section present")
-                .forbid
-                .is_empty()
-        );
+        let MiddlewareSettings::Static(st) = &s.http.middleware[0];
+        assert!(st.forbid.is_empty());
 
         for entry in ["php", "", ".", ".php ", "./php"] {
             let file = load_str(&format!(

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -572,6 +572,14 @@ mod tests {
         let file = load_str("[pool]\nentrypoint = \"a.php\"\n").unwrap();
         let s = merge(file, Overrides::default(), Some(Path::new("/w"))).unwrap();
         assert!(s.http.static_files.is_none());
+
+        let file = load_str("[pool]\nentrypoint = \"a.php\"\n[http.static]\nroot = \"/srv/pub\"\n")
+            .unwrap();
+        let s = merge(file, Overrides::default(), Some(Path::new("/w"))).unwrap();
+        assert_eq!(
+            s.http.static_files.expect("section present").root,
+            Path::new("/srv/pub")
+        );
     }
 
     #[test]
@@ -591,16 +599,16 @@ mod tests {
         }
     }
 
-    /// Extensions compare case-insensitively at request time, so entries normalize to lowercase here.
+    /// The resolver validates shape only. The middleware constructor normalizes the case.
     #[test]
-    fn http_static_forbid_validates_and_lowercases() {
+    fn http_static_forbid_validates() {
         let file = load_str(
             "[pool]\nentrypoint = \"a.php\"\n[http.static]\nroot = \"p\"\nforbid = [\".PHP\", \".Phtml\"]\n",
         )
         .unwrap();
         let s = merge(file, Overrides::default(), Some(Path::new("/w"))).unwrap();
         let st = s.http.static_files.expect("section present");
-        assert_eq!(st.forbid, vec![".php".to_owned(), ".phtml".to_owned()]);
+        assert_eq!(st.forbid, vec![".PHP".to_owned(), ".Phtml".to_owned()]);
 
         let file =
             load_str("[pool]\nentrypoint = \"a.php\"\n[http.static]\nroot = \"p\"\nforbid = []\n")
@@ -614,7 +622,7 @@ mod tests {
                 .is_empty()
         );
 
-        for entry in ["php", ""] {
+        for entry in ["php", "", ".", ".php ", "./php"] {
             let file = load_str(&format!(
                 "[pool]\nentrypoint = \"a.php\"\n[http.static]\nroot = \"p\"\nforbid = [\"{entry}\"]\n"
             ))

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -10,13 +10,13 @@ mod log;
 mod pool;
 mod supervisor;
 
-pub use http::{HttpSettings, UnsafeFieldNames, UploadSettings};
+pub use http::{HttpSettings, StaticSettings, UnsafeFieldNames, UploadSettings};
 pub use listen::{Listen, ListenParseError};
 pub use log::{LogFormat, LogLevel, LogSettings};
 pub use pool::{PoolSettings, RunMode, Scaling};
 pub use supervisor::SupervisorSettings;
 
-use http::{HttpSection, resolve_uploads};
+use http::{HttpSection, resolve_static, resolve_uploads};
 use log::{LogSection, resolve_log};
 use pool::{PoolSection, resolve_pool};
 use supervisor::{SupervisorSection, resolve_supervisor};
@@ -117,6 +117,11 @@ fn merge(file: FileConfig, cli: Overrides, config_dir: Option<&Path>) -> anyhow:
         None => None,
     };
 
+    let static_files = match file.http.r#static {
+        Some(section) => Some(resolve_static(section, config_dir)?),
+        None => None,
+    };
+
     let pool = resolve_pool(file.pool, &cli, config_dir, "pool")?;
     if file.http.uploads.is_some() && pool.mode != RunMode::Dispatcher {
         bail!(
@@ -142,6 +147,7 @@ fn merge(file: FileConfig, cli: Overrides, config_dir: Option<&Path>) -> anyhow:
             unsafe_field_names: file.http.unsafe_field_names.unwrap_or_default(),
             uploads,
             sendfile_root,
+            static_files,
         },
         pool,
         supervisor,
@@ -284,6 +290,7 @@ mod tests {
         assert!(load_str("[log]\nbogus = 1\n").is_err());
         assert!(load_str("[log]\nlevel = \"verbose\"\n").is_err());
         assert!(load_str("[log]\nformat = \"pretty\"\n").is_err());
+        assert!(load_str("[http.static]\nbogus = 1\n").is_err());
     }
 
     #[test]
@@ -550,6 +557,73 @@ mod tests {
             s.supervisor.pidfile.as_deref(),
             Some(Path::new("/etc/rapira/rapira.pid"))
         );
+    }
+
+    /// The root resolves config-relative like every other path key; forbid defaults to the PHP source guard.
+    #[test]
+    fn http_static_resolves_with_defaults() {
+        let file =
+            load_str("[pool]\nentrypoint = \"a.php\"\n[http.static]\nroot = \"public\"\n").unwrap();
+        let s = merge(file, Overrides::default(), Some(Path::new("/w"))).unwrap();
+        let st = s.http.static_files.expect("section present");
+        assert_eq!(st.root, Path::new("/w/public"));
+        assert_eq!(st.forbid, vec![".php".to_owned()]);
+
+        let file = load_str("[pool]\nentrypoint = \"a.php\"\n").unwrap();
+        let s = merge(file, Overrides::default(), Some(Path::new("/w"))).unwrap();
+        assert!(s.http.static_files.is_none());
+    }
+
+    #[test]
+    fn http_static_requires_root() {
+        for toml in [
+            "[pool]\nentrypoint = \"a.php\"\n[http.static]\n",
+            "[pool]\nentrypoint = \"a.php\"\n[http.static]\nroot = \"\"\n",
+        ] {
+            let err = merge(
+                load_str(toml).unwrap(),
+                Overrides::default(),
+                Some(Path::new("/w")),
+            )
+            .unwrap_err()
+            .to_string();
+            assert!(err.contains("http.static.root"), "{err}");
+        }
+    }
+
+    /// Extensions compare case-insensitively at request time, so entries normalize to lowercase here.
+    #[test]
+    fn http_static_forbid_validates_and_lowercases() {
+        let file = load_str(
+            "[pool]\nentrypoint = \"a.php\"\n[http.static]\nroot = \"p\"\nforbid = [\".PHP\", \".Phtml\"]\n",
+        )
+        .unwrap();
+        let s = merge(file, Overrides::default(), Some(Path::new("/w"))).unwrap();
+        let st = s.http.static_files.expect("section present");
+        assert_eq!(st.forbid, vec![".php".to_owned(), ".phtml".to_owned()]);
+
+        let file =
+            load_str("[pool]\nentrypoint = \"a.php\"\n[http.static]\nroot = \"p\"\nforbid = []\n")
+                .unwrap();
+        let s = merge(file, Overrides::default(), Some(Path::new("/w"))).unwrap();
+        assert!(
+            s.http
+                .static_files
+                .expect("section present")
+                .forbid
+                .is_empty()
+        );
+
+        for entry in ["php", ""] {
+            let file = load_str(&format!(
+                "[pool]\nentrypoint = \"a.php\"\n[http.static]\nroot = \"p\"\nforbid = [\"{entry}\"]\n"
+            ))
+            .unwrap();
+            let err = merge(file, Overrides::default(), Some(Path::new("/w")))
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("http.static.forbid"), "{entry}: {err}");
+        }
     }
 
     /// The filter string is assembled from these keys, so a key carrying filter syntax would inject directives (`"php=trace,tokio" = "debug"` reads as two).

--- a/crates/middleware/static_files/Cargo.toml
+++ b/crates/middleware/static_files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapira_static_files"
-version = "0.8.0"
+version = "0.7.0"
 edition.workspace = true
 publish = false
 license = "MIT"

--- a/crates/middleware/static_files/Cargo.toml
+++ b/crates/middleware/static_files/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "rapira_static_files"
+version = "0.8.0"
+edition.workspace = true
+publish = false
+license = "MIT"
+description = "Static file middleware for the rapira HTTP front"
+
+[lints]
+workspace = true
+
+[dependencies]
+extension_api = { workspace = true }
+bytes = { workspace = true }
+http = { workspace = true }
+http-body-util = { workspace = true }
+tracing = { workspace = true }
+percent-encoding = "2"
+tower-http = { version = "0.7", default-features = false, features = ["fs"] }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/middleware/static_files/src/lib.rs
+++ b/crates/middleware/static_files/src/lib.rs
@@ -7,7 +7,8 @@ use http_body_util::{BodyExt, Empty};
 use tower_http::services::ServeDir;
 
 /// Serves files from a directory and hands every miss to the next middleware.
-/// A read failure answers 500. The request does not reach the next middleware.
+/// A permission error or a bad file name is also a miss. Any other read failure
+/// answers 500. That request does not reach the next middleware.
 pub struct StaticFiles {
     dir: ServeDir,
     forbid: Vec<String>,
@@ -22,7 +23,9 @@ impl StaticFiles {
             entry.make_ascii_lowercase();
         }
         Self {
-            dir: ServeDir::new(root),
+            // The URL space belongs to PHP: a directory URL is the app's route, not an
+            // implicit index.html.
+            dir: ServeDir::new(root).append_index_html_on_directories(false),
             forbid,
         }
     }
@@ -36,13 +39,13 @@ impl StaticFiles {
         if decoded.split('/').any(|segment| segment.starts_with('.')) {
             return false;
         }
-        // The last non-empty segment is the file ServeDir resolves: its component walk drops
-        // trailing separators, so `/index.php%2F` still names index.php here.
+        // The last non-empty segment is the served file; the component walk drops trailing
+        // separators, so `/index.php%2F` still names index.php here.
         let file = decoded
             .rsplit('/')
             .find(|s| !s.is_empty())
-            .unwrap_or_default();
-        let file = file.to_ascii_lowercase();
+            .unwrap_or_default()
+            .to_ascii_lowercase();
         !self.forbid.iter().any(|ext| file.ends_with(ext.as_str()))
     }
 }
@@ -66,12 +69,7 @@ impl Middleware for StaticFiles {
 
             let mut dir = self.dir.clone();
             match dir.try_call(probe).await {
-                // A 307 names a directory, not a file this middleware can serve. It falls
-                // through so PHP owns the URL shape.
-                Ok(res)
-                    if res.status() != StatusCode::NOT_FOUND
-                        && res.status() != StatusCode::TEMPORARY_REDIRECT =>
-                {
+                Ok(res) if res.status() != StatusCode::NOT_FOUND => {
                     res.map(|b| b.map_err(|e| -> BoxError { Box::new(e) }).boxed_unsync())
                 }
                 // ServeDir folds NotFound, PermissionDenied and ENOTDIR into Ok(404), so an
@@ -263,10 +261,10 @@ mod tests {
         assert_eq!(body(res).await, "a{}");
     }
 
-    /// A trailing slash resolves to the directory's index.html. Without that file the request is a miss.
     #[tokio::test(flavor = "current_thread")]
-    async fn directory_paths_with_a_trailing_slash_fall_through_without_an_index() {
+    async fn directory_paths_with_a_trailing_slash_fall_through() {
         let dir = root();
+        std::fs::write(dir.path().join("sub").join("index.html"), "<h1>s</h1>").unwrap();
         for path in ["/assets/", "/sub/"] {
             let res = run(static_files(&dir), request("GET", path, "")).await;
             assert_eq!(header(&res, "x-handler"), "php", "{path}");
@@ -391,12 +389,15 @@ mod tests {
         assert_eq!(body(res).await, "");
     }
 
+    /// The URL space belongs to PHP: no implicit index resolution, only exact file paths serve.
     #[tokio::test(flavor = "current_thread")]
-    async fn the_root_serves_index_html() {
+    async fn the_root_falls_through_even_with_an_index_present() {
         let dir = root();
         let res = run(static_files(&dir), request("GET", "/", "")).await;
+        assert_eq!(header(&res, "x-handler"), "php");
+
+        let res = run(static_files(&dir), request("GET", "/index.html", "")).await;
         assert_eq!(res.status(), 200);
-        assert_eq!(header(&res, "content-type"), "text/html");
         assert_eq!(body(res).await, "<h1>hi</h1>");
     }
 

--- a/crates/middleware/static_files/src/lib.rs
+++ b/crates/middleware/static_files/src/lib.rs
@@ -1,0 +1,331 @@
+use std::path::PathBuf;
+
+use bytes::Bytes;
+use extension_api::{BoxError, BoxFuture, HttpRequest, HttpResponse, Middleware, Next};
+use http::{Method, StatusCode};
+use http_body_util::{BodyExt, Empty};
+use tower_http::services::ServeDir;
+
+/// Serves files from a directory and hands every miss to the next middleware.
+pub struct StaticFiles {
+    dir: ServeDir,
+    forbid: Vec<String>,
+}
+
+impl StaticFiles {
+    /// `root` must be absolute; `forbid` holds lowercase extensions with a leading dot.
+    pub fn new(root: PathBuf, forbid: Vec<String>) -> Self {
+        Self {
+            dir: ServeDir::new(root),
+            forbid,
+        }
+    }
+
+    /// The check runs on the decoded path because ServeDir percent-decodes before it touches
+    /// the filesystem; matching the raw path would let `%2Ephp` through.
+    fn eligible(&self, path: &str) -> bool {
+        let Ok(decoded) = percent_encoding::percent_decode_str(path).decode_utf8() else {
+            return false;
+        };
+        if decoded.split('/').any(|segment| segment.starts_with('.')) {
+            return false;
+        }
+        // file_name() drops trailing separators the way ServeDir's component walk does, so
+        // `/index.php%2F` still names index.php here.
+        let file = std::path::Path::new(decoded.as_ref())
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or_default();
+        let file = file.to_ascii_lowercase();
+        !self.forbid.iter().any(|ext| file.ends_with(ext.as_str()))
+    }
+}
+
+impl Middleware for StaticFiles {
+    fn handle<'a>(&'a self, req: HttpRequest, next: Next) -> BoxFuture<'a, HttpResponse> {
+        Box::pin(async move {
+            if req.method() != Method::GET && req.method() != Method::HEAD {
+                return next.run(req).await;
+            }
+            if !self.eligible(req.uri().path()) {
+                return next.run(req).await;
+            }
+
+            // The probe carries only the head; the original request stays intact for the
+            // miss path, so the Peer and Protocol extensions reach the handler untouched.
+            let mut probe = http::Request::new(Empty::<Bytes>::new());
+            *probe.method_mut() = req.method().clone();
+            *probe.uri_mut() = req.uri().clone();
+            *probe.headers_mut() = req.headers().clone();
+
+            let mut dir = self.dir.clone();
+            match dir.try_call(probe).await {
+                // A 307 names a directory, not a servable file; it falls through so PHP owns
+                // the URL shape.
+                Ok(res)
+                    if res.status() != StatusCode::NOT_FOUND
+                        && res.status() != StatusCode::TEMPORARY_REDIRECT =>
+                {
+                    res.map(|b| b.map_err(|e| -> BoxError { Box::new(e) }).boxed_unsync())
+                }
+                Ok(_) => next.run(req).await,
+                // A name-shaped error (segment over NAME_MAX, NUL byte) is a miss, not a failure.
+                Err(e)
+                    if matches!(
+                        e.kind(),
+                        std::io::ErrorKind::InvalidFilename | std::io::ErrorKind::InvalidInput
+                    ) =>
+                {
+                    next.run(req).await
+                }
+                // try_call answers Ok(404) for a missing or unreadable file, so an Err here is
+                // a real read failure and must not reach PHP. https://docs.rs/tower-http/0.7.0/tower_http/services/struct.ServeDir.html#method.try_call
+                Err(e) => {
+                    tracing::error!(target: "http", "static probe failed for {}: {e}", req.uri().path());
+                    http::Response::builder()
+                        .status(StatusCode::INTERNAL_SERVER_ERROR)
+                        .body(Empty::new().map_err(|e| match e {}).boxed_unsync())
+                        .unwrap()
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use extension_api::{Addr, BoxFuture, Handler, Middleware, Peer, Protocol};
+    use http_body_util::{BodyExt, Full};
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+
+    fn peer() -> Peer {
+        let addr: SocketAddr = "127.0.0.1:9".parse().unwrap();
+        Peer {
+            remote: Addr::Inet(addr),
+            server: Addr::Inet(addr),
+            https: false,
+            received_at: 0.0,
+        }
+    }
+
+    /// Marks fallthrough: the response reports whether the extensions and body survived.
+    struct Fallthrough;
+
+    impl Handler for Fallthrough {
+        fn call<'a>(&'a self, req: HttpRequest) -> BoxFuture<'a, HttpResponse> {
+            Box::pin(async move {
+                let kept = req.extensions().get::<Peer>().is_some()
+                    && req.extensions().get::<Protocol>().is_some();
+                let body = req.into_body().collect().await.unwrap().to_bytes();
+                http::Response::builder()
+                    .status(200)
+                    .header("x-handler", "php")
+                    .header("x-extensions", if kept { "kept" } else { "lost" })
+                    .body(Full::new(body).map_err(|e| match e {}).boxed_unsync())
+                    .unwrap()
+            })
+        }
+    }
+
+    fn request(method: &str, path: &str, body: &str) -> HttpRequest {
+        let mut req = http::Request::builder()
+            .method(method)
+            .uri(path)
+            .body(
+                Full::new(Bytes::from(body.to_owned()))
+                    .map_err(|e| match e {})
+                    .boxed_unsync(),
+            )
+            .unwrap();
+        req.extensions_mut().insert(Protocol::Http);
+        req.extensions_mut().insert(peer());
+        req
+    }
+
+    async fn run(st: StaticFiles, req: HttpRequest) -> HttpResponse {
+        let chain: Arc<[Arc<dyn Middleware>]> =
+            Arc::from(vec![Arc::new(st) as Arc<dyn Middleware>]);
+        Next::new(chain, Arc::new(Fallthrough)).run(req).await
+    }
+
+    fn root() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("styles.css"), "body{}").unwrap();
+        std::fs::write(dir.path().join("data.bin"), "abcdefghij").unwrap();
+        std::fs::write(dir.path().join("index.html"), "<h1>hi</h1>").unwrap();
+        std::fs::write(dir.path().join("index.php"), "<?php secret();").unwrap();
+        std::fs::write(dir.path().join(".env"), "SECRET=1").unwrap();
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+        std::fs::write(dir.path().join(".git").join("config"), "[core]").unwrap();
+        std::fs::write(dir.path().join("Upper.PHP"), "<?php upper();").unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        std::fs::write(dir.path().join("sub").join("index.php"), "<?php sub();").unwrap();
+        std::fs::create_dir(dir.path().join("assets")).unwrap();
+        std::fs::write(dir.path().join("assets").join("a.css"), "a{}").unwrap();
+        dir
+    }
+
+    fn static_files(dir: &tempfile::TempDir) -> StaticFiles {
+        StaticFiles::new(dir.path().to_path_buf(), vec![".php".to_owned()])
+    }
+
+    fn header<'r>(res: &'r HttpResponse, name: &str) -> &'r str {
+        res.headers()
+            .get(name)
+            .unwrap_or_else(|| panic!("{name} missing"))
+            .to_str()
+            .unwrap()
+    }
+
+    async fn body(res: HttpResponse) -> Bytes {
+        res.into_body().collect().await.unwrap().to_bytes()
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn serves_a_file_with_type_length_and_validators() {
+        let dir = root();
+        let res = run(static_files(&dir), request("GET", "/styles.css", "")).await;
+        assert_eq!(res.status(), 200);
+        assert!(res.headers().get("x-handler").is_none());
+        assert_eq!(header(&res, "content-type"), "text/css");
+        assert_eq!(header(&res, "content-length"), "6");
+        assert_eq!(header(&res, "accept-ranges"), "bytes");
+        assert!(res.headers().contains_key("etag"));
+        assert!(res.headers().contains_key("last-modified"));
+        assert_eq!(body(res).await, "body{}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_miss_falls_through_with_the_request_intact() {
+        let dir = root();
+        let res = run(static_files(&dir), request("GET", "/nope.txt", "ping")).await;
+        assert_eq!(header(&res, "x-handler"), "php");
+        assert_eq!(header(&res, "x-extensions"), "kept");
+        assert_eq!(body(res).await, "ping");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn non_get_head_methods_fall_through() {
+        let dir = root();
+        let res = run(static_files(&dir), request("POST", "/styles.css", "p")).await;
+        assert_eq!(header(&res, "x-handler"), "php");
+        assert_eq!(body(res).await, "p");
+    }
+
+    /// The encoded-slash forms decode to a trailing separator that ServeDir drops when it resolves the file.
+    #[tokio::test(flavor = "current_thread")]
+    async fn forbidden_extensions_fall_through_even_when_the_file_exists() {
+        let dir = root();
+        for path in [
+            "/index.php",
+            "/INDEX.PHP",
+            "/index%2Ephp",
+            "/Upper.PHP",
+            "/index.php%2F",
+            "/index.php%2F%2F",
+            "/sub/index.php%2F",
+        ] {
+            let res = run(static_files(&dir), request("GET", path, "")).await;
+            assert_eq!(header(&res, "x-handler"), "php", "{path}");
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn directory_paths_without_a_trailing_slash_fall_through() {
+        let dir = root();
+        for path in ["/assets", "/sub"] {
+            let res = run(static_files(&dir), request("GET", path, "")).await;
+            assert_eq!(header(&res, "x-handler"), "php", "{path}");
+        }
+
+        let res = run(static_files(&dir), request("GET", "/assets/a.css", "")).await;
+        assert_eq!(res.status(), 200);
+        assert_eq!(body(res).await, "a{}");
+    }
+
+    /// A segment over NAME_MAX surfaces from try_call as an Err with a name-shaped kind, not as a 404.
+    #[tokio::test(flavor = "current_thread")]
+    async fn overlong_and_undecodable_paths_fall_through() {
+        let dir = root();
+        let long = format!("/{}", "a".repeat(300));
+        for path in [long.as_str(), "/%FF.css"] {
+            let res = run(static_files(&dir), request("GET", path, "")).await;
+            assert_eq!(header(&res, "x-handler"), "php", "{path}");
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dotfile_segments_fall_through() {
+        let dir = root();
+        for path in ["/.env", "/.git/config", "/%2Eenv"] {
+            let res = run(static_files(&dir), request("GET", path, "")).await;
+            assert_eq!(header(&res, "x-handler"), "php", "{path}");
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn traversal_attempts_fall_through() {
+        let dir = root();
+        for path in ["/../outside.txt", "/%2e%2e/outside.txt"] {
+            let res = run(static_files(&dir), request("GET", path, "")).await;
+            assert_eq!(header(&res, "x-handler"), "php", "{path}");
+        }
+    }
+
+    /// Byte positions are inclusive (RFC 9110 section 14.1.2, https://www.rfc-editor.org/rfc/rfc9110#section-14.1.2); Content-Range carries first-pos "-" last-pos "/" complete-length (section 14.4, https://www.rfc-editor.org/rfc/rfc9110#section-14.4).
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_range_request_answers_the_named_bytes() {
+        let dir = root();
+        let mut req = request("GET", "/data.bin", "");
+        req.headers_mut()
+            .insert("range", "bytes=0-4".parse().unwrap());
+        let res = run(static_files(&dir), req).await;
+        assert_eq!(res.status(), 206);
+        assert_eq!(header(&res, "content-range"), "bytes 0-4/10");
+        assert_eq!(header(&res, "content-length"), "5");
+        assert_eq!(body(res).await, "abcde");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn if_none_match_with_the_served_etag_answers_304() {
+        let dir = root();
+        let first = run(static_files(&dir), request("GET", "/data.bin", "")).await;
+        let etag = header(&first, "etag").to_owned();
+
+        let mut req = request("GET", "/data.bin", "");
+        req.headers_mut()
+            .insert("if-none-match", etag.parse().unwrap());
+        let res = run(static_files(&dir), req).await;
+        assert_eq!(res.status(), 304);
+        assert_eq!(body(res).await, "");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn head_answers_the_full_length_without_a_body() {
+        let dir = root();
+        let res = run(static_files(&dir), request("HEAD", "/data.bin", "")).await;
+        assert_eq!(res.status(), 200);
+        assert_eq!(header(&res, "content-length"), "10");
+        assert_eq!(body(res).await, "");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn the_root_serves_index_html() {
+        let dir = root();
+        let res = run(static_files(&dir), request("GET", "/", "")).await;
+        assert_eq!(res.status(), 200);
+        assert_eq!(header(&res, "content-type"), "text/html");
+        assert_eq!(body(res).await, "<h1>hi</h1>");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn query_strings_do_not_affect_resolution() {
+        let dir = root();
+        let res = run(static_files(&dir), request("GET", "/styles.css?v=2", "")).await;
+        assert_eq!(res.status(), 200);
+        assert_eq!(body(res).await, "body{}");
+    }
+}

--- a/crates/middleware/static_files/src/lib.rs
+++ b/crates/middleware/static_files/src/lib.rs
@@ -94,7 +94,7 @@ impl Middleware for StaticFiles {
                     tracing::error!(target: "http", "static probe failed for {}: {e}", req.uri().path());
                     http::Response::builder()
                         .status(StatusCode::INTERNAL_SERVER_ERROR)
-                        .body(Empty::new().map_err(|e| match e {}).boxed_unsync())
+                        .body(empty_body())
                         .unwrap()
                 }
             }

--- a/crates/middleware/static_files/src/lib.rs
+++ b/crates/middleware/static_files/src/lib.rs
@@ -1,28 +1,34 @@
 use std::path::PathBuf;
 
 use bytes::Bytes;
-use extension_api::{BoxError, BoxFuture, HttpRequest, HttpResponse, Middleware, Next};
+use extension_api::{BoxError, BoxFuture, HttpRequest, HttpResponse, Middleware, Next, empty_body};
 use http::{Method, StatusCode};
 use http_body_util::{BodyExt, Empty};
 use tower_http::services::ServeDir;
 
 /// Serves files from a directory and hands every miss to the next middleware.
+/// A read failure answers 500. The request does not reach the next middleware.
 pub struct StaticFiles {
     dir: ServeDir,
     forbid: Vec<String>,
 }
 
 impl StaticFiles {
-    /// `root` must be absolute; `forbid` holds lowercase extensions with a leading dot.
-    pub fn new(root: PathBuf, forbid: Vec<String>) -> Self {
+    /// A relative `root` resolves against the process working directory.
+    /// `forbid` holds file-name suffixes with a leading dot.
+    /// The constructor lowercases them, so an uppercase entry still matches in `eligible`.
+    pub fn new(root: PathBuf, mut forbid: Vec<String>) -> Self {
+        for entry in &mut forbid {
+            entry.make_ascii_lowercase();
+        }
         Self {
             dir: ServeDir::new(root),
             forbid,
         }
     }
 
-    /// The check runs on the decoded path because ServeDir percent-decodes before it touches
-    /// the filesystem; matching the raw path would let `%2Ephp` through.
+    /// The check runs on the decoded path because ServeDir percent-decodes before it reads
+    /// the filesystem. A match on the raw path would accept `%2Ephp`.
     fn eligible(&self, path: &str) -> bool {
         let Ok(decoded) = percent_encoding::percent_decode_str(path).decode_utf8() else {
             return false;
@@ -30,11 +36,11 @@ impl StaticFiles {
         if decoded.split('/').any(|segment| segment.starts_with('.')) {
             return false;
         }
-        // file_name() drops trailing separators the way ServeDir's component walk does, so
-        // `/index.php%2F` still names index.php here.
-        let file = std::path::Path::new(decoded.as_ref())
-            .file_name()
-            .and_then(|f| f.to_str())
+        // The last non-empty segment is the file ServeDir resolves: its component walk drops
+        // trailing separators, so `/index.php%2F` still names index.php here.
+        let file = decoded
+            .rsplit('/')
+            .find(|s| !s.is_empty())
             .unwrap_or_default();
         let file = file.to_ascii_lowercase();
         !self.forbid.iter().any(|ext| file.ends_with(ext.as_str()))
@@ -51,8 +57,8 @@ impl Middleware for StaticFiles {
                 return next.run(req).await;
             }
 
-            // The probe carries only the head; the original request stays intact for the
-            // miss path, so the Peer and Protocol extensions reach the handler untouched.
+            // The probe carries only the head. The original request stays unchanged for the
+            // miss path, so the Peer and Protocol extensions reach the handler.
             let mut probe = http::Request::new(Empty::<Bytes>::new());
             *probe.method_mut() = req.method().clone();
             *probe.uri_mut() = req.uri().clone();
@@ -60,16 +66,20 @@ impl Middleware for StaticFiles {
 
             let mut dir = self.dir.clone();
             match dir.try_call(probe).await {
-                // A 307 names a directory, not a servable file; it falls through so PHP owns
-                // the URL shape.
+                // A 307 names a directory, not a file this middleware can serve. It falls
+                // through so PHP owns the URL shape.
                 Ok(res)
                     if res.status() != StatusCode::NOT_FOUND
                         && res.status() != StatusCode::TEMPORARY_REDIRECT =>
                 {
                     res.map(|b| b.map_err(|e| -> BoxError { Box::new(e) }).boxed_unsync())
                 }
+                // ServeDir folds NotFound, PermissionDenied and ENOTDIR into Ok(404), so an
+                // unreadable file is indistinguishable from a missing one and reaches PHP.
                 Ok(_) => next.run(req).await,
-                // A name-shaped error (segment over NAME_MAX, NUL byte) is a miss, not a failure.
+                // An error about the file name is a miss. A segment over NAME_MAX returns
+                // InvalidFilename. A HEAD probe returns InvalidInput for a NUL byte; a GET
+                // answers 404 for it.
                 Err(e)
                     if matches!(
                         e.kind(),
@@ -78,8 +88,8 @@ impl Middleware for StaticFiles {
                 {
                     next.run(req).await
                 }
-                // try_call answers Ok(404) for a missing or unreadable file, so an Err here is
-                // a real read failure and must not reach PHP. https://docs.rs/tower-http/0.7.0/tower_http/services/struct.ServeDir.html#method.try_call
+                // An Err outside the file-name kinds is a read failure and must not reach
+                // PHP. https://docs.rs/tower-http/0.7.0/tower_http/services/struct.ServeDir.html#method.try_call
                 Err(e) => {
                     tracing::error!(target: "http", "static probe failed for {}: {e}", req.uri().path());
                     http::Response::builder()
@@ -95,9 +105,8 @@ impl Middleware for StaticFiles {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bytes::Bytes;
-    use extension_api::{Addr, BoxFuture, Handler, Middleware, Peer, Protocol};
-    use http_body_util::{BodyExt, Full};
+    use extension_api::{Addr, Handler, Peer, Protocol};
+    use http_body_util::Full;
     use std::net::SocketAddr;
     use std::sync::Arc;
 
@@ -221,7 +230,6 @@ mod tests {
         let dir = root();
         for path in [
             "/index.php",
-            "/INDEX.PHP",
             "/index%2Ephp",
             "/Upper.PHP",
             "/index.php%2F",
@@ -231,6 +239,15 @@ mod tests {
             let res = run(static_files(&dir), request("GET", path, "")).await;
             assert_eq!(header(&res, "x-handler"), "php", "{path}");
         }
+    }
+
+    /// The constructor lowercases the entries, so an uppercase entry still blocks the PHP source.
+    #[tokio::test(flavor = "current_thread")]
+    async fn uppercase_forbid_needles_are_normalized() {
+        let dir = root();
+        let st = StaticFiles::new(dir.path().to_path_buf(), vec![".PHP".to_owned()]);
+        let res = run(st, request("GET", "/index.php", "")).await;
+        assert_eq!(header(&res, "x-handler"), "php");
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -246,36 +263,98 @@ mod tests {
         assert_eq!(body(res).await, "a{}");
     }
 
-    /// A segment over NAME_MAX surfaces from try_call as an Err with a name-shaped kind, not as a 404.
+    /// A trailing slash resolves to the directory's index.html. Without that file the request is a miss.
     #[tokio::test(flavor = "current_thread")]
-    async fn overlong_and_undecodable_paths_fall_through() {
+    async fn directory_paths_with_a_trailing_slash_fall_through_without_an_index() {
         let dir = root();
-        let long = format!("/{}", "a".repeat(300));
-        for path in [long.as_str(), "/%FF.css"] {
+        for path in ["/assets/", "/sub/"] {
             let res = run(static_files(&dir), request("GET", path, "")).await;
             assert_eq!(header(&res, "x-handler"), "php", "{path}");
         }
     }
 
+    /// An empty forbid list is explicit: the middleware serves every file in the root.
+    #[tokio::test(flavor = "current_thread")]
+    async fn an_empty_forbid_list_serves_php_sources() {
+        let dir = root();
+        let st = StaticFiles::new(dir.path().to_path_buf(), Vec::new());
+        let res = run(st, request("GET", "/index.php", "")).await;
+        assert_eq!(res.status(), 200);
+        assert!(res.headers().get("x-handler").is_none());
+        assert_eq!(body(res).await, "<?php secret();");
+    }
+
+    /// An unsatisfiable byte range answers 416 (RFC 9110 section 15.5.17, https://www.rfc-editor.org/rfc/rfc9110#section-15.5.17).
+    /// The response carries unsatisfied-range `"*/" complete-length` (section 14.4, https://www.rfc-editor.org/rfc/rfc9110#section-14.4).
+    /// The file exists, so the middleware answers and PHP does not see the request.
+    #[tokio::test(flavor = "current_thread")]
+    async fn an_unsatisfiable_range_answers_416_without_reaching_php() {
+        let dir = root();
+        let mut req = request("GET", "/data.bin", "");
+        req.headers_mut()
+            .insert("range", "bytes=100-200".parse().unwrap());
+        let res = run(static_files(&dir), req).await;
+        assert_eq!(res.status(), 416);
+        assert_eq!(header(&res, "content-range"), "bytes */10");
+        assert!(res.headers().get("x-handler").is_none());
+    }
+
+    /// A symlink loop fails with ELOOP. That kind is not in ServeDir's miss set (NotFound,
+    /// PermissionDenied, ENOTDIR) and is not a file-name error, so it is a read failure.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_real_read_failure_answers_500() {
+        let dir = root();
+        std::os::unix::fs::symlink("loop.css", dir.path().join("loop.css")).unwrap();
+        let res = run(static_files(&dir), request("GET", "/loop.css", "")).await;
+        assert_eq!(res.status(), 500);
+        assert!(res.headers().get("x-handler").is_none());
+        assert_eq!(body(res).await, "");
+    }
+
+    /// A segment over NAME_MAX surfaces from try_call as an Err with a file-name kind, not as a 404.
+    #[tokio::test(flavor = "current_thread")]
+    async fn an_overlong_segment_falls_through() {
+        let dir = root();
+        let long = format!("/{}", "a".repeat(300));
+        let res = run(static_files(&dir), request("GET", &long, "")).await;
+        assert_eq!(header(&res, "x-handler"), "php");
+    }
+
+    /// A NUL byte reaches the file-name arm on HEAD only. A GET already folds it into a 404.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_nul_byte_in_the_path_falls_through() {
+        let dir = root();
+        for method in ["GET", "HEAD"] {
+            let res = run(static_files(&dir), request(method, "/a%00.css", "")).await;
+            assert_eq!(header(&res, "x-handler"), "php", "{method}");
+        }
+    }
+
+    /// The middleware cannot check an undecodable path against the dot and forbid rules, so the path is never eligible.
+    #[test]
+    fn an_undecodable_path_is_never_eligible() {
+        let dir = root();
+        assert!(!static_files(&dir).eligible("/%FF.css"));
+    }
+
+    /// Parent-dir segments land on the same guard: `..` starts with a dot.
     #[tokio::test(flavor = "current_thread")]
     async fn dotfile_segments_fall_through() {
         let dir = root();
-        for path in ["/.env", "/.git/config", "/%2Eenv"] {
+        for path in [
+            "/.env",
+            "/.git/config",
+            "/%2Eenv",
+            "/../outside.txt",
+            "/%2e%2e/outside.txt",
+        ] {
             let res = run(static_files(&dir), request("GET", path, "")).await;
             assert_eq!(header(&res, "x-handler"), "php", "{path}");
         }
     }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn traversal_attempts_fall_through() {
-        let dir = root();
-        for path in ["/../outside.txt", "/%2e%2e/outside.txt"] {
-            let res = run(static_files(&dir), request("GET", path, "")).await;
-            assert_eq!(header(&res, "x-handler"), "php", "{path}");
-        }
-    }
-
-    /// Byte positions are inclusive (RFC 9110 section 14.1.2, https://www.rfc-editor.org/rfc/rfc9110#section-14.1.2); Content-Range carries first-pos "-" last-pos "/" complete-length (section 14.4, https://www.rfc-editor.org/rfc/rfc9110#section-14.4).
+    /// Byte positions are inclusive (RFC 9110 section 14.1.2, https://www.rfc-editor.org/rfc/rfc9110#section-14.1.2).
+    /// Content-Range carries first-pos "-" last-pos "/" complete-length (section 14.4, https://www.rfc-editor.org/rfc/rfc9110#section-14.4).
     #[tokio::test(flavor = "current_thread")]
     async fn a_range_request_answers_the_named_bytes() {
         let dir = root();

--- a/crates/plugins/tower/README.md
+++ b/crates/plugins/tower/README.md
@@ -12,7 +12,7 @@ Connections are served by hyper's http1 builder. Each request runs through admis
 
 `Config.middleware` holds an `extension_api::Middleware` chain, outermost first, shared by every protocol this plugin serves. A middleware sees `http::Request<Body>`/`http::Response<Body>` with `Protocol` and `Peer` in the request extensions, and either calls `next.run(req)` or answers on its own. Admission checks run before the chain, so middleware never sees a request that was refused at the door.
 
-Built-in middleware lives under `crates/middleware`, one crate per middleware. `rapira_static_files::StaticFiles` serves files from `[http.static].root`. A miss falls through the chain to PHP. A permission error or a bad file name is also a miss. Any other read failure answers 500. That request does not reach PHP.
+Built-in middleware lives under `crates/middleware`, one crate per middleware. The `middleware` list in `[http]` selects the built-in middleware and sets the chain order. `rapira_static_files::StaticFiles` serves files from `[http.static].root`. A miss falls through the chain to PHP. A permission error or a bad file name is also a miss. Any other read failure answers 500. That request does not reach PHP.
 
 ## Request handling
 

--- a/crates/plugins/tower/README.md
+++ b/crates/plugins/tower/README.md
@@ -12,7 +12,7 @@ Connections are served by hyper's http1 builder. Each request runs through admis
 
 `Config.middleware` holds an `extension_api::Middleware` chain, outermost first, shared by every protocol this plugin serves. A middleware sees `http::Request<Body>`/`http::Response<Body>` with `Protocol` and `Peer` in the request extensions, and either calls `next.run(req)` or answers on its own. Admission checks run before the chain, so middleware never sees a request that was refused at the door.
 
-Built-in middleware lives under `crates/middleware`, one crate per middleware. `rapira_static_files::StaticFiles` serves files from `[http.static].root`. A miss falls through the chain to PHP. A read failure answers 500. That request does not reach PHP.
+Built-in middleware lives under `crates/middleware`, one crate per middleware. `rapira_static_files::StaticFiles` serves files from `[http.static].root`. A miss falls through the chain to PHP. A permission error or a bad file name is also a miss. Any other read failure answers 500. That request does not reach PHP.
 
 ## Request handling
 

--- a/crates/plugins/tower/README.md
+++ b/crates/plugins/tower/README.md
@@ -12,6 +12,8 @@ Connections are served by hyper's http1 builder. Each request runs through admis
 
 `Config.middleware` holds an `extension_api::Middleware` chain, outermost first, shared by every protocol this plugin serves. A middleware sees `http::Request<Body>`/`http::Response<Body>` with `Protocol` and `Peer` in the request extensions, and either calls `next.run(req)` or answers on its own. Admission checks run before the chain, so middleware never sees a request that was refused at the door.
 
+Built-in middleware lives under `crates/middleware`, one crate per middleware. `rapira_static_files::StaticFiles` serves files from `[http.static].root` and hands every miss to PHP. Only file hits answer: a directory path without a trailing slash falls through as well.
+
 ## Request handling
 
 - The request body is buffered before dispatch and capped by `max_body_size`: a declared `Content-Length` over the cap answers 413 before the body is read, an over-long streamed body answers 413 when the cap is crossed.

--- a/crates/plugins/tower/README.md
+++ b/crates/plugins/tower/README.md
@@ -12,7 +12,7 @@ Connections are served by hyper's http1 builder. Each request runs through admis
 
 `Config.middleware` holds an `extension_api::Middleware` chain, outermost first, shared by every protocol this plugin serves. A middleware sees `http::Request<Body>`/`http::Response<Body>` with `Protocol` and `Peer` in the request extensions, and either calls `next.run(req)` or answers on its own. Admission checks run before the chain, so middleware never sees a request that was refused at the door.
 
-Built-in middleware lives under `crates/middleware`, one crate per middleware. `rapira_static_files::StaticFiles` serves files from `[http.static].root` and hands every miss to PHP. Only file hits answer: a directory path without a trailing slash falls through as well.
+Built-in middleware lives under `crates/middleware`, one crate per middleware. `rapira_static_files::StaticFiles` serves files from `[http.static].root`. A miss falls through the chain to PHP. A read failure answers 500. That request does not reach PHP.
 
 ## Request handling
 

--- a/crates/plugins/tower/src/handler.rs
+++ b/crates/plugins/tower/src/handler.rs
@@ -164,8 +164,6 @@ where
         received_at,
     };
 
-    // future middleware are here -----------
-    // TODO: so/dylib vs code?
     if shared.chain.is_empty() {
         return serve_php(
             &shared,

--- a/crates/plugins/tower/src/response.rs
+++ b/crates/plugins/tower/src/response.rs
@@ -1,12 +1,5 @@
-use extension_api::{BoxError, FieldLines, HttpResponse};
+use extension_api::{FieldLines, HttpResponse, empty_body};
 use http::header::{CACHE_CONTROL, CONNECTION, CONTENT_LENGTH, HeaderMap, HeaderName, HeaderValue};
-use http_body_util::BodyExt;
-
-pub(crate) fn empty_body() -> extension_api::Body {
-    http_body_util::Empty::<bytes::Bytes>::new()
-        .map_err(BoxError::from)
-        .boxed_unsync()
-}
 
 pub(crate) fn error_response(status: http::StatusCode) -> HttpResponse {
     let mut res = http::Response::new(empty_body());

--- a/crates/tests/tests/e2e/harness.rs
+++ b/crates/tests/tests/e2e/harness.rs
@@ -191,6 +191,47 @@ fn spawn_with_extras(
     panic!("rapira never accepted a connection after 3 attempts\n{last_log}");
 }
 
+/// Boots expecting a startup failure: waits for the exit and returns the status with the log tail.
+pub fn spawn_boot_failure(fixture: &str, http_extra: &str) -> (std::process::ExitStatus, String) {
+    let dir = scratch_dir();
+    let name = Path::new(fixture)
+        .file_name()
+        .unwrap_or_else(|| panic!("fixture {fixture} has no file name"));
+    std::fs::copy(fixture_path(fixture), dir.join(name))
+        .unwrap_or_else(|e| panic!("copy fixture {fixture}: {e}"));
+    let entrypoint = name.to_str().expect("fixture name is utf-8");
+    std::fs::write(
+        dir.join("rapira.toml"),
+        render_config(free_port(), 1, entrypoint, http_extra, ""),
+    )
+    .expect("write config");
+    let log = File::create(dir.join("server.log")).expect("create server.log");
+    let mut cmd = Command::new(rapira_bin());
+    cmd.args(["serve", "--config"]).arg(dir.join("rapira.toml"));
+    cmd.env_remove("PHPRC");
+    cmd.env("RUST_LOG", "info");
+    let mut child = cmd
+        .stdout(Stdio::from(log.try_clone().expect("clone log fd")))
+        .stderr(Stdio::from(log))
+        .spawn()
+        .expect("spawn rapira");
+    let end = Instant::now() + Duration::from_secs(30);
+    let status = loop {
+        if let Some(st) = child.try_wait().expect("try_wait") {
+            break st;
+        }
+        if Instant::now() >= end {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("rapira did not exit\n{}", log_tail(&dir));
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    let tail = log_tail(&dir);
+    let _ = std::fs::remove_dir_all(&dir);
+    (status, tail)
+}
+
 fn render_config(
     port: u16,
     processes: usize,

--- a/crates/tests/tests/e2e/harness.rs
+++ b/crates/tests/tests/e2e/harness.rs
@@ -142,44 +142,21 @@ fn spawn_with_extras(
     rust_log: Option<&str>,
     cwd_ini: Option<CwdIni<'_>>,
 ) -> Server {
-    let dir = scratch_dir();
-    let name = Path::new(fixture)
-        .file_name()
-        .unwrap_or_else(|| panic!("fixture {fixture} has no file name"));
-    std::fs::copy(fixture_path(fixture), dir.join(name))
-        .unwrap_or_else(|e| panic!("copy fixture {fixture}: {e}"));
-    let entrypoint = name.to_str().expect("fixture name is utf-8");
+    let (dir, entrypoint) = stage_fixture(fixture);
     if let Some(ini) = &cwd_ini {
         std::fs::write(dir.join("php.ini"), ini.contents).expect("write php.ini");
     }
     let mut last_log = String::new();
     for _ in 0..3 {
-        let port = free_port();
-        let addr = SocketAddr::from(([127, 0, 0, 1], port));
-        std::fs::write(
-            dir.join("rapira.toml"),
-            render_config(port, processes, entrypoint, http_extra, extra_toml),
-        )
-        .expect("write config");
-        let log = File::create(dir.join("server.log")).expect("create server.log");
-        let mut cmd = Command::new(rapira_bin());
-        cmd.args(["serve", "--config"]).arg(dir.join("rapira.toml"));
-        cmd.env_remove("PHPRC");
-        if let Some(ini) = &cwd_ini {
-            cmd.current_dir(&dir);
-            if ini.via_phprc {
-                cmd.env("PHPRC", &dir);
-            }
-        }
-        match rust_log {
-            Some(v) => cmd.env("RUST_LOG", v),
-            None => cmd.env_remove("RUST_LOG"),
-        };
-        let mut child = cmd
-            .stdout(Stdio::from(log.try_clone().expect("clone log fd")))
-            .stderr(Stdio::from(log))
-            .spawn()
-            .expect("spawn rapira");
+        let (mut child, addr) = spawn_attempt(
+            &dir,
+            processes,
+            &entrypoint,
+            http_extra,
+            extra_toml,
+            rust_log,
+            cwd_ini.as_ref(),
+        );
         if wait_for_port(&addr, &mut child, BOOT) {
             return Server { child, addr, dir };
         }
@@ -191,45 +168,69 @@ fn spawn_with_extras(
     panic!("rapira never accepted a connection after 3 attempts\n{last_log}");
 }
 
-/// Boots expecting a startup failure: waits for the exit and returns the status with the log tail.
-pub fn spawn_boot_failure(fixture: &str, http_extra: &str) -> (std::process::ExitStatus, String) {
+/// A scratch dir holding a copy of the fixture, plus the entrypoint name for the config.
+fn stage_fixture(fixture: &str) -> (PathBuf, String) {
     let dir = scratch_dir();
     let name = Path::new(fixture)
         .file_name()
         .unwrap_or_else(|| panic!("fixture {fixture} has no file name"));
     std::fs::copy(fixture_path(fixture), dir.join(name))
         .unwrap_or_else(|e| panic!("copy fixture {fixture}: {e}"));
-    let entrypoint = name.to_str().expect("fixture name is utf-8");
+    let entrypoint = name.to_str().expect("fixture name is utf-8").to_owned();
+    (dir, entrypoint)
+}
+
+/// One spawn on a fresh port; the caller decides how to wait.
+fn spawn_attempt(
+    dir: &Path,
+    processes: usize,
+    entrypoint: &str,
+    http_extra: &str,
+    extra_toml: &str,
+    rust_log: Option<&str>,
+    cwd_ini: Option<&CwdIni<'_>>,
+) -> (Child, SocketAddr) {
+    let port = free_port();
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
     std::fs::write(
         dir.join("rapira.toml"),
-        render_config(free_port(), 1, entrypoint, http_extra, ""),
+        render_config(port, processes, entrypoint, http_extra, extra_toml),
     )
     .expect("write config");
     let log = File::create(dir.join("server.log")).expect("create server.log");
     let mut cmd = Command::new(rapira_bin());
     cmd.args(["serve", "--config"]).arg(dir.join("rapira.toml"));
     cmd.env_remove("PHPRC");
-    cmd.env("RUST_LOG", "info");
-    let mut child = cmd
+    if let Some(ini) = cwd_ini {
+        cmd.current_dir(dir);
+        if ini.via_phprc {
+            cmd.env("PHPRC", dir);
+        }
+    }
+    match rust_log {
+        Some(v) => cmd.env("RUST_LOG", v),
+        None => cmd.env_remove("RUST_LOG"),
+    };
+    let child = cmd
         .stdout(Stdio::from(log.try_clone().expect("clone log fd")))
         .stderr(Stdio::from(log))
         .spawn()
         .expect("spawn rapira");
-    let end = Instant::now() + Duration::from_secs(30);
-    let status = loop {
-        if let Some(st) = child.try_wait().expect("try_wait") {
-            break st;
-        }
-        if Instant::now() >= end {
-            let _ = child.kill();
-            let _ = child.wait();
-            panic!("rapira did not exit\n{}", log_tail(&dir));
-        }
-        std::thread::sleep(Duration::from_millis(50));
+    (child, addr)
+}
+
+/// Boots expecting a startup failure: waits for the exit and returns the status with the log.
+/// The function returns the whole log, not the tail: with `RUST_BACKTRACE` set, the backtrace
+/// after the error line is longer than the tail window.
+pub fn spawn_boot_failure(fixture: &str, http_extra: &str) -> (ExitStatus, String) {
+    let (dir, entrypoint) = stage_fixture(fixture);
+    let (child, addr) = spawn_attempt(&dir, 1, &entrypoint, http_extra, "", Some("info"), None);
+    let mut srv = Server { child, addr, dir };
+    let Some(status) = srv.wait_exit(BOOT) else {
+        panic!("rapira did not exit");
     };
-    let tail = log_tail(&dir);
-    let _ = std::fs::remove_dir_all(&dir);
-    (status, tail)
+    let log = std::fs::read_to_string(srv.dir.join("server.log")).unwrap_or_default();
+    (status, log)
 }
 
 fn render_config(
@@ -602,7 +603,7 @@ fn log_tail(dir: &Path) -> String {
     )
 }
 
-fn scratch_dir() -> PathBuf {
+pub fn scratch_dir() -> PathBuf {
     static SEQ: AtomicU64 = AtomicU64::new(0);
     let seq = SEQ.fetch_add(1, Ordering::Relaxed);
     let dir = std::env::temp_dir().join(format!("rapira-e2e-{}-{seq}", std::process::id()));

--- a/crates/tests/tests/e2e/main.rs
+++ b/crates/tests/tests/e2e/main.rs
@@ -7,4 +7,5 @@ mod lifecycle;
 mod logging;
 mod reload;
 mod scaling;
+mod static_files;
 mod streaming;

--- a/crates/tests/tests/e2e/static_files.rs
+++ b/crates/tests/tests/e2e/static_files.rs
@@ -87,6 +87,35 @@ fn a_missing_static_root_refuses_to_boot() {
     );
 }
 
+/// An existing directory without read access passes a plain stat, so the boot check must open it.
+#[test]
+fn an_unreadable_static_root_refuses_to_boot() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = scratch_dir();
+    let root = dir.join("root");
+    std::fs::create_dir(&root).expect("create root");
+    std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o000)).expect("chmod root");
+    // Root bypasses permission checks; the case cannot occur for that user.
+    if std::fs::read_dir(&root).is_ok() {
+        let _ = std::fs::remove_dir_all(&dir);
+        return;
+    }
+    let (status, log) = spawn_boot_failure(
+        "shared/echo-worker.php",
+        &format!(
+            "middleware = [\"static\"]\n[http.static]\nroot = \"{}\"\n",
+            root.display()
+        ),
+    );
+    std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o755)).expect("restore root");
+    let _ = std::fs::remove_dir_all(&dir);
+    assert_eq!(status.code(), Some(1), "{log}");
+    assert!(
+        log.contains("http.static.root") && log.contains("is not readable"),
+        "{log}"
+    );
+}
+
 #[test]
 fn a_static_root_that_is_not_a_directory_refuses_to_boot() {
     let dir = scratch_dir();

--- a/crates/tests/tests/e2e/static_files.rs
+++ b/crates/tests/tests/e2e/static_files.rs
@@ -82,12 +82,12 @@ fn a_missing_static_root_refuses_to_boot() {
     );
     assert_eq!(status.code(), Some(1), "{log}");
     assert!(
-        log.contains("http.static.root") && log.contains("is not readable"),
+        log.contains("http.static.root") && log.contains("is not accessible"),
         "{log}"
     );
 }
 
-/// An existing directory without read access passes a plain stat, so the boot check must open it.
+/// A 000 directory passes a stat of its own path; the boot probe must resolve inside it.
 #[test]
 fn an_unreadable_static_root_refuses_to_boot() {
     use std::os::unix::fs::PermissionsExt;
@@ -111,7 +111,36 @@ fn an_unreadable_static_root_refuses_to_boot() {
     let _ = std::fs::remove_dir_all(&dir);
     assert_eq!(status.code(), Some(1), "{log}");
     assert!(
-        log.contains("http.static.root") && log.contains("is not readable"),
+        log.contains("http.static.root") && log.contains("is not accessible"),
+        "{log}"
+    );
+}
+
+/// A 0400 root lists but cannot resolve child paths; boot must require search permission.
+#[test]
+fn a_static_root_without_search_permission_refuses_to_boot() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = scratch_dir();
+    let root = dir.join("root");
+    std::fs::create_dir(&root).expect("create root");
+    std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o400)).expect("chmod root");
+    // Root bypasses permission checks; the case cannot occur for that user.
+    if std::fs::metadata(root.join(".")).is_ok() {
+        let _ = std::fs::remove_dir_all(&dir);
+        return;
+    }
+    let (status, log) = spawn_boot_failure(
+        "shared/echo-worker.php",
+        &format!(
+            "middleware = [\"static\"]\n[http.static]\nroot = \"{}\"\n",
+            root.display()
+        ),
+    );
+    std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o755)).expect("restore root");
+    let _ = std::fs::remove_dir_all(&dir);
+    assert_eq!(status.code(), Some(1), "{log}");
+    assert!(
+        log.contains("http.static.root") && log.contains("is not accessible"),
         "{log}"
     );
 }

--- a/crates/tests/tests/e2e/static_files.rs
+++ b/crates/tests/tests/e2e/static_files.rs
@@ -26,7 +26,10 @@ fn static_files_serve_over_the_wire() {
     let srv = spawn_with_http_extra(
         "shared/echo-worker.php",
         1,
-        &format!("[http.static]\nroot = \"{}\"\n", root.display()),
+        &format!(
+            "middleware = [\"static\"]\n[http.static]\nroot = \"{}\"\n",
+            root.display()
+        ),
     );
 
     let raw = http_get_raw(srv.addr, "/app.css", &[], T).expect("GET /app.css");
@@ -75,7 +78,7 @@ fn static_files_serve_over_the_wire() {
 fn a_missing_static_root_refuses_to_boot() {
     let (status, log) = spawn_boot_failure(
         "shared/echo-worker.php",
-        "[http.static]\nroot = \"/nonexistent-rapira-static-root\"\n",
+        "middleware = [\"static\"]\n[http.static]\nroot = \"/nonexistent-rapira-static-root\"\n",
     );
     assert_eq!(status.code(), Some(1), "{log}");
     assert!(
@@ -91,7 +94,10 @@ fn a_static_root_that_is_not_a_directory_refuses_to_boot() {
     std::fs::write(&file, "x").expect("write file root");
     let (status, log) = spawn_boot_failure(
         "shared/echo-worker.php",
-        &format!("[http.static]\nroot = \"{}\"\n", file.display()),
+        &format!(
+            "middleware = [\"static\"]\n[http.static]\nroot = \"{}\"\n",
+            file.display()
+        ),
     );
     let _ = std::fs::remove_dir_all(&dir);
     assert_eq!(status.code(), Some(1), "{log}");

--- a/crates/tests/tests/e2e/static_files.rs
+++ b/crates/tests/tests/e2e/static_files.rs
@@ -1,15 +1,13 @@
 use crate::harness::{
-    diagnostics, http_get, http_get_raw, spawn_boot_failure, spawn_with_http_extra,
+    diagnostics, http_get, http_get_raw, http_post, scratch_dir, spawn_boot_failure,
+    spawn_with_http_extra,
 };
 use std::time::Duration;
 
 const T: Duration = Duration::from_secs(10);
 
 fn static_root(files: &[(&str, &str)]) -> std::path::PathBuf {
-    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let dir = std::env::temp_dir().join(format!("rapira-static-{}-{seq}", std::process::id()));
-    std::fs::create_dir_all(&dir).expect("create static root");
+    let dir = scratch_dir();
     for (name, contents) in files {
         std::fs::write(dir.join(name), contents).expect("write static file");
     }
@@ -31,17 +29,26 @@ fn static_files_serve_over_the_wire() {
         &format!("[http.static]\nroot = \"{}\"\n", root.display()),
     );
 
-    let (code, body) = http_get(srv.addr, "/app.css", T).expect("GET /app.css");
-    assert_eq!(code, 200, "\n{}", diagnostics(&srv));
-    assert_eq!(body, b"body{color:red}");
-    let raw = http_get_raw(srv.addr, "/app.css", &[], T).expect("raw GET /app.css");
-    let head = String::from_utf8_lossy(&raw).to_lowercase();
-    assert!(head.contains("content-type: text/css"), "{head}");
-    assert!(head.contains("content-length: 15"), "{head}");
+    let raw = http_get_raw(srv.addr, "/app.css", &[], T).expect("GET /app.css");
+    let text = String::from_utf8_lossy(&raw);
+    assert!(
+        text.starts_with("HTTP/1.1 200"),
+        "{text}\n{}",
+        diagnostics(&srv)
+    );
+    let head = text.split("\r\n\r\n").next().expect("head").to_lowercase();
+    assert!(head.contains("\r\ncontent-type: text/css\r\n"), "{head}");
+    assert!(head.contains("\r\ncontent-length: 15\r\n"), "{head}");
+    assert!(text.ends_with("body{color:red}"), "{text}");
 
     let (code, body) = http_get(srv.addr, "/nope", T).expect("GET /nope");
     assert_eq!(code, 200, "\n{}", diagnostics(&srv));
     assert!(body.starts_with(b"ok:"), "a miss must reach php");
+
+    let (code, body) =
+        http_post(srv.addr, "/nope", b"text/plain", b"payload", T).expect("POST /nope");
+    assert_eq!(code, 200, "\n{}", diagnostics(&srv));
+    assert!(body.starts_with(b"ok:"), "a post must reach php");
 
     for path in ["/index.php", "/.env"] {
         let (_, body) = http_get(srv.addr, path, T).expect(path);
@@ -70,6 +77,23 @@ fn a_missing_static_root_refuses_to_boot() {
         "shared/echo-worker.php",
         "[http.static]\nroot = \"/nonexistent-rapira-static-root\"\n",
     );
-    assert!(!status.success(), "{log}");
-    assert!(log.contains("http.static.root"), "{log}");
+    assert_eq!(status.code(), Some(1), "{log}");
+    assert!(
+        log.contains("http.static.root") && log.contains("is not readable"),
+        "{log}"
+    );
+}
+
+#[test]
+fn a_static_root_that_is_not_a_directory_refuses_to_boot() {
+    let dir = scratch_dir();
+    let file = dir.join("root");
+    std::fs::write(&file, "x").expect("write file root");
+    let (status, log) = spawn_boot_failure(
+        "shared/echo-worker.php",
+        &format!("[http.static]\nroot = \"{}\"\n", file.display()),
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+    assert_eq!(status.code(), Some(1), "{log}");
+    assert!(log.contains("is not a directory"), "{log}");
 }

--- a/crates/tests/tests/e2e/static_files.rs
+++ b/crates/tests/tests/e2e/static_files.rs
@@ -1,0 +1,75 @@
+use crate::harness::{
+    diagnostics, http_get, http_get_raw, spawn_boot_failure, spawn_with_http_extra,
+};
+use std::time::Duration;
+
+const T: Duration = Duration::from_secs(10);
+
+fn static_root(files: &[(&str, &str)]) -> std::path::PathBuf {
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("rapira-static-{}-{seq}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create static root");
+    for (name, contents) in files {
+        std::fs::write(dir.join(name), contents).expect("write static file");
+    }
+    dir
+}
+
+/// One boot covers the wire behavior: a hit with its headers, a miss into PHP, the source and dotfile guards, and a range.
+#[test]
+fn static_files_serve_over_the_wire() {
+    let root = static_root(&[
+        ("app.css", "body{color:red}"),
+        ("big.bin", "0123456789"),
+        ("index.php", "<?php leak();"),
+        (".env", "SECRET=1"),
+    ]);
+    let srv = spawn_with_http_extra(
+        "shared/echo-worker.php",
+        1,
+        &format!("[http.static]\nroot = \"{}\"\n", root.display()),
+    );
+
+    let (code, body) = http_get(srv.addr, "/app.css", T).expect("GET /app.css");
+    assert_eq!(code, 200, "\n{}", diagnostics(&srv));
+    assert_eq!(body, b"body{color:red}");
+    let raw = http_get_raw(srv.addr, "/app.css", &[], T).expect("raw GET /app.css");
+    let head = String::from_utf8_lossy(&raw).to_lowercase();
+    assert!(head.contains("content-type: text/css"), "{head}");
+    assert!(head.contains("content-length: 15"), "{head}");
+
+    let (code, body) = http_get(srv.addr, "/nope", T).expect("GET /nope");
+    assert_eq!(code, 200, "\n{}", diagnostics(&srv));
+    assert!(body.starts_with(b"ok:"), "a miss must reach php");
+
+    for path in ["/index.php", "/.env"] {
+        let (_, body) = http_get(srv.addr, path, T).expect(path);
+        assert!(
+            body.starts_with(b"ok:"),
+            "{path} must reach php, got {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+
+    let raw = http_get_raw(srv.addr, "/big.bin", &[("Range", "bytes=0-3")], T).expect("range GET");
+    let text = String::from_utf8_lossy(&raw);
+    assert!(text.starts_with("HTTP/1.1 206"), "{text}");
+    assert!(
+        text.to_lowercase().contains("content-range: bytes 0-3/10"),
+        "{text}"
+    );
+    assert!(text.ends_with("0123"), "{text}");
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_missing_static_root_refuses_to_boot() {
+    let (status, log) = spawn_boot_failure(
+        "shared/echo-worker.php",
+        "[http.static]\nroot = \"/nonexistent-rapira-static-root\"\n",
+    );
+    assert!(!status.success(), "{log}");
+    assert!(log.contains("http.static.root"), "{log}");
+}

--- a/examples/rapira.toml
+++ b/examples/rapira.toml
@@ -9,6 +9,7 @@ listen = "127.0.0.1:8000"    # host:port, ":port" (all interfaces), or "unix:/pa
 # write_timeout_secs = 30    # closes the connection when a response write stalls this long
 # keepalive_timeout_secs = 60 # closes a keepalive connection idle past the limit; also caps one head or body-frame read
 # unsafe_field_names = "drop" # or "reject": 400 for header names aliasing a CGI variable
+# middleware = ["static"]    # applied in list order; each configured middleware must be listed
 
 # Host-side multipart limits - dispatcher mode only (classic/worker parse in PHP,
 # where php.ini owns the limits); an explicit table under another mode refuses to boot.
@@ -21,6 +22,7 @@ listen = "127.0.0.1:8000"    # host:port, ":port" (all interfaces), or "unix:/pa
 # root = "public"            # sendFile() containment; defaults to the entrypoint's directory
 
 # Serve files from a directory before PHP. A miss falls through to PHP. Dotfiles always fall through to PHP.
+# Requires "static" in http.middleware.
 # [http.static]
 # root = "public"            # required; the directory must exist; relative paths resolve against this file's directory
 # forbid = [".php"]          # file-name suffixes the server never serves; an explicit list replaces this default

--- a/examples/rapira.toml
+++ b/examples/rapira.toml
@@ -20,6 +20,11 @@ listen = "127.0.0.1:8000"    # host:port, ":port" (all interfaces), or "unix:/pa
 # [http.sendfile]
 # root = "public"            # sendFile() containment; defaults to the entrypoint's directory
 
+# Serve files from a directory before PHP; a miss falls through to PHP.
+# [http.static]
+# root = "public"            # required; relative paths resolve against this file's directory
+# forbid = [".php"]          # extensions never served; dotfiles always fall through to PHP
+
 [pool]
 entrypoint = "dispatcher.php" # relative paths resolve against this file's directory
 mode = "dispatcher"           # "classic" | "worker" | "dispatcher" (the default)

--- a/examples/rapira.toml
+++ b/examples/rapira.toml
@@ -20,10 +20,10 @@ listen = "127.0.0.1:8000"    # host:port, ":port" (all interfaces), or "unix:/pa
 # [http.sendfile]
 # root = "public"            # sendFile() containment; defaults to the entrypoint's directory
 
-# Serve files from a directory before PHP; a miss falls through to PHP.
+# Serve files from a directory before PHP. A miss falls through to PHP. Dotfiles always fall through to PHP.
 # [http.static]
-# root = "public"            # required; relative paths resolve against this file's directory
-# forbid = [".php"]          # extensions never served; dotfiles always fall through to PHP
+# root = "public"            # required; the directory must exist; relative paths resolve against this file's directory
+# forbid = [".php"]          # file-name suffixes the server never serves; an explicit list replaces this default
 
 [pool]
 entrypoint = "dispatcher.php" # relative paths resolve against this file's directory

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use extension_api::{ListenAddr, Middleware, PrepareCtx};
 use php_sys::{Mode, Rapira};
-use rapira_config::{Listen, Overrides, RunMode, Scaling, Settings, UnsafeFieldNames};
+use rapira_config::{
+    Listen, MiddlewareSettings, Overrides, RunMode, Scaling, Settings, UnsafeFieldNames,
+};
 use rapira_runtime::ExtensionRuntime;
 use rapira_scoreboard::Scoreboard;
 use rapira_tower::{Config as HttpConfig, HttpServer, UnsafeFieldNames as HttpUnsafeFieldNames};
@@ -120,26 +122,30 @@ fn serve(args: ServeArgs) -> anyhow::Result<()> {
             .unwrap_or_else(|| PathBuf::from("/")),
     );
 
-    // static files --------------------------------------------------
+    // middleware ---------------------------------------------------
     let mut middleware: Vec<Arc<dyn Middleware>> = Vec::new();
-    if let Some(st) = &settings.http.static_files {
-        // is_dir() folds every stat error into false; metadata keeps the errno visible.
-        let meta = std::fs::metadata(&st.root).map_err(|e| {
-            anyhow::anyhow!(
-                "http.static.root {} is not readable: {e}",
-                st.root.display()
-            )
-        })?;
-        anyhow::ensure!(
-            meta.is_dir(),
-            "http.static.root {} is not a directory",
-            st.root.display()
-        );
-        info!(target: "rapira", "static files from {}, forbid {:?}", st.root.display(), st.forbid);
-        middleware.push(Arc::new(rapira_static_files::StaticFiles::new(
-            st.root.clone(),
-            st.forbid.clone(),
-        )));
+    for mw in &settings.http.middleware {
+        match mw {
+            MiddlewareSettings::Static(st) => {
+                // is_dir() folds every stat error into false; metadata keeps the errno visible.
+                let meta = std::fs::metadata(&st.root).map_err(|e| {
+                    anyhow::anyhow!(
+                        "http.static.root {} is not readable: {e}",
+                        st.root.display()
+                    )
+                })?;
+                anyhow::ensure!(
+                    meta.is_dir(),
+                    "http.static.root {} is not a directory",
+                    st.root.display()
+                );
+                info!(target: "rapira", "static files from {}, forbid {:?}", st.root.display(), st.forbid);
+                middleware.push(Arc::new(rapira_static_files::StaticFiles::new(
+                    st.root.clone(),
+                    st.forbid.clone(),
+                )));
+            }
+        }
     }
     //----------------------------------------------------------------
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,14 @@ fn serve(args: ServeArgs) -> anyhow::Result<()> {
                     "http.static.root {} is not a directory",
                     st.root.display()
                 );
+                // A stat succeeds without read access on the directory itself; only opening
+                // the directory proves the workers can serve from it.
+                std::fs::read_dir(&st.root).map_err(|e| {
+                    anyhow::anyhow!(
+                        "http.static.root {} is not readable: {e}",
+                        st.root.display()
+                    )
+                })?;
                 info!(target: "rapira", "static files from {}, forbid {:?}", st.root.display(), st.forbid);
                 middleware.push(Arc::new(rapira_static_files::StaticFiles::new(
                     st.root.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Args, CommandFactory, Parser, Subcommand};
-use extension_api::{ListenAddr, PrepareCtx};
+use extension_api::{ListenAddr, Middleware, PrepareCtx};
 use php_sys::{Mode, Rapira};
 use rapira_config::{Listen, Overrides, RunMode, Scaling, Settings, UnsafeFieldNames};
 use rapira_runtime::ExtensionRuntime;
@@ -8,6 +8,7 @@ use rapira_tower::{Config as HttpConfig, HttpServer, UnsafeFieldNames as HttpUns
 use std::{
     fs::{OpenOptions, read_dir, remove_file},
     path::PathBuf,
+    sync::Arc,
 };
 use tracing::info;
 
@@ -119,6 +120,21 @@ fn serve(args: ServeArgs) -> anyhow::Result<()> {
             .unwrap_or_else(|| PathBuf::from("/")),
     );
 
+    // static files --------------------------------------------------
+    let mut middleware: Vec<Arc<dyn Middleware>> = Vec::new();
+    if let Some(st) = &settings.http.static_files {
+        anyhow::ensure!(
+            st.root.is_dir(),
+            "http.static.root {} is not a directory",
+            st.root.display()
+        );
+        middleware.push(Arc::new(rapira_static_files::StaticFiles::new(
+            st.root.clone(),
+            st.forbid.clone(),
+        )));
+    }
+    //----------------------------------------------------------------
+
     // parse HTTP configuration -------------------------------------
     let http_cfg: HttpConfig = HttpConfig {
         listen: match settings.http.listen {
@@ -136,7 +152,7 @@ fn serve(args: ServeArgs) -> anyhow::Result<()> {
         },
         superglobals: !matches!(mode, Mode::Dispatcher(_)),
         keepalive_timeout: settings.http.keepalive_timeout,
-        middleware: Vec::new(),
+        middleware,
     };
     //----------------------------------------------------------------
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,11 +123,19 @@ fn serve(args: ServeArgs) -> anyhow::Result<()> {
     // static files --------------------------------------------------
     let mut middleware: Vec<Arc<dyn Middleware>> = Vec::new();
     if let Some(st) = &settings.http.static_files {
+        // is_dir() folds every stat error into false; metadata keeps the errno visible.
+        let meta = std::fs::metadata(&st.root).map_err(|e| {
+            anyhow::anyhow!(
+                "http.static.root {} is not readable: {e}",
+                st.root.display()
+            )
+        })?;
         anyhow::ensure!(
-            st.root.is_dir(),
+            meta.is_dir(),
             "http.static.root {} is not a directory",
             st.root.display()
         );
+        info!(target: "rapira", "static files from {}, forbid {:?}", st.root.display(), st.forbid);
         middleware.push(Arc::new(rapira_static_files::StaticFiles::new(
             st.root.clone(),
             st.forbid.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,7 @@ fn serve(args: ServeArgs) -> anyhow::Result<()> {
                 // is_dir() folds every stat error into false; metadata keeps the errno visible.
                 let meta = std::fs::metadata(&st.root).map_err(|e| {
                     anyhow::anyhow!(
-                        "http.static.root {} is not readable: {e}",
+                        "http.static.root {} is not accessible: {e}",
                         st.root.display()
                     )
                 })?;
@@ -139,11 +139,10 @@ fn serve(args: ServeArgs) -> anyhow::Result<()> {
                     "http.static.root {} is not a directory",
                     st.root.display()
                 );
-                // A stat succeeds without read access on the directory itself; only opening
-                // the directory proves the workers can serve from it.
-                std::fs::read_dir(&st.root).map_err(|e| {
+                // Serving needs search permission, not read; resolving `.` inside the root proves it.
+                std::fs::metadata(st.root.join(".")).map_err(|e| {
                     anyhow::anyhow!(
-                        "http.static.root {} is not readable: {e}",
+                        "http.static.root {} is not accessible: {e}",
                         st.root.display()
                     )
                 })?;


### PR DESCRIPTION
# Reason for This PR

- closes: #76 

## Description of Changes

- Added support for serving static content via `ServeDir` in the `tower_http` service.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] The PR title is a conventional commit (`feat:`, `fix:`, `chore:`, ...), issue no. at the end.
- [x] All added/changed functionality is tested.