### PR TITLE
fix(worker): preserve retained SPL temporary streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ lcov.info
 *.profdata
 .claude/settings.local.json
 AGENTS.local.md
+.DS_Store

--- a/crates/php_sys/module.c
+++ b/crates/php_sys/module.c
@@ -459,6 +459,7 @@ void rapira_release_temporary_streams(void) {
         if (val->type == stream_type) {
             php_stream *stream = val->ptr;
             if (stream != NULL && stream->ops == &php_stream_temp_ops &&
+                !(stream->flags & PHP_STREAM_FLAG_NO_FCLOSE) &&
                 stream->__exposed == 0 && GC_REFCOUNT(val) == 1) {
                 zend_list_delete(val);
             }

--- a/crates/tests/tests/e2e/fixtures/lifecycle/retained-temp-worker.php
+++ b/crates/tests/tests/e2e/fixtures/lifecycle/retained-temp-worker.php
@@ -1,0 +1,17 @@
+<?php
+$export = null;
+$requests = 0;
+$handler = static function () use (&$export, &$requests): void {
+    ++$requests;
+    header('Content-Type: text/plain');
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        $export = new SplTempFileObject();
+        $export->fwrite(file_get_contents('php://input'));
+        echo getmypid(), ':', $requests, ':stored';
+        return;
+    }
+    $export->rewind();
+    echo getmypid(), ':', $requests, ':', $export->fgets();
+};
+while (\Rapira\handle_request($handler)) {
+}

--- a/crates/tests/tests/e2e/lifecycle.rs
+++ b/crates/tests/tests/e2e/lifecycle.rs
@@ -33,6 +33,48 @@ fn http_round_trip() {
 }
 
 #[test]
+fn retained_spl_tempfile_survives_next_request() {
+    let srv = spawn_with_config(
+        "lifecycle/retained-temp-worker.php",
+        1,
+        "mode = \"worker\"\n",
+    );
+    let timeout = Duration::from_secs(10);
+    let pid = wait_workers(&srv, timeout, "1 worker", |p| p.len() == 1)[0];
+
+    for (index, contents) in ["first export\n", "replacement export\n"]
+        .into_iter()
+        .enumerate()
+    {
+        let (code, body) = http_post(
+            srv.addr,
+            "/export",
+            b"text/plain",
+            contents.as_bytes(),
+            timeout,
+        )
+        .unwrap_or_else(|e| panic!("POST /export: {e}\n{}", diagnostics(&srv)));
+        assert_eq!(code, 200, "\n{}", diagnostics(&srv));
+        assert_eq!(
+            body,
+            format!("{pid}:{}:stored", index * 2 + 1).into_bytes(),
+            "\n{}",
+            diagnostics(&srv)
+        );
+
+        let (code, body) = http_get(srv.addr, "/export", timeout)
+            .unwrap_or_else(|e| panic!("GET /export: {e}\n{}", diagnostics(&srv)));
+        assert_eq!(code, 200, "\n{}", diagnostics(&srv));
+        assert_eq!(
+            body,
+            format!("{pid}:{}:{contents}", index * 2 + 2).into_bytes(),
+            "\n{}",
+            diagnostics(&srv)
+        );
+    }
+}
+
+#[test]
 fn killed_worker_respawns() {
     let srv = spawn_with_config("shared/echo-worker.php", 2, "");
     let pids0 = wait_workers(&srv, Duration::from_secs(20), "2 workers", |p| p.len() == 2);


### PR DESCRIPTION
- Preserve SPL-owned temporary streams during worker request cleanup.
- Add worker-mode HTTP coverage for retained `SplTempFileObject` reads and replacement.
- Ignore `.DS_Store` files.